### PR TITLE
fix: terraform fmt alignment in vm.tf

### DIFF
--- a/terraform/vm.tf
+++ b/terraform/vm.tf
@@ -28,7 +28,7 @@ resource "azurerm_linux_virtual_machine" "traffic_gen" {
   }
 
   custom_data = base64encode(templatefile("${path.module}/cloud-init.yaml", {
-    target_fqdn     = var.target_fqdn
+    target_fqdn      = var.target_fqdn
     target_origin_ip = var.target_origin_ip
     tool_tier        = var.tool_tier
   }))


### PR DESCRIPTION
Closes #4

## Summary
- Fixes terraform fmt whitespace alignment in `terraform/vm.tf` templatefile() block
- Super-linter runs `terraform fmt -check` on PRs — this prevents CI failure

## Test plan
- [x] `terraform fmt -check -recursive terraform/` passes locally
- [x] `terraform validate` passes
- [x] `checkov --config-file .checkov.yaml -d terraform/` passes (9/0/0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)