### PR TITLE
fix: use _data/ paths for remark-code-import file= directives

### DIFF
--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -20,26 +20,26 @@ cp terraform.tfvars.example terraform.tfvars
 
 `main.tf` configures the Azure provider:
 
-```hcl file=../terraform/main.tf
+```hcl file=./_data/main.tf
 ```
 
 `variables.tf` defines all configurable parameters. The `vm_size` default is `Standard_F16s_v2` (16 vCPU compute-optimized) — see [VM Sizing](#vm-sizing) for scaling guidance:
 
-```hcl file=../terraform/variables.tf
+```hcl file=./_data/variables.tf
 ```
 
 ### Network Infrastructure
 
 `network.tf` creates the VNet, subnet, public IP, NSG (port 22 SSH), and NIC:
 
-```hcl file=../terraform/network.tf
+```hcl file=./_data/network.tf
 ```
 
 ### Virtual Machine with Cloud-Init
 
 `vm.tf` creates the Ubuntu 24.04 VM and passes the cloud-init template with target and tooling variables:
 
-```hcl file=../terraform/vm.tf
+```hcl file=./_data/vm.tf
 ```
 
 ### Cloud-Init Provisioning
@@ -59,21 +59,21 @@ cp terraform.tfvars.example terraform.tfvars
 
 The cloud-init uses Terraform template variables: `${target_fqdn}`, `${target_origin_ip}`, and `${tool_tier}`. Shell variables like `$NPROC` are escaped as `$$NPROC` in the Terraform templatefile.
 
-```yaml file=../terraform/cloud-init.yaml
+```yaml file=./_data/cloud-init.yaml
 ```
 
 ### Outputs
 
 `outputs.tf` exposes the public IP, SSH command, target FQDN, status check, and resource group:
 
-```hcl file=../terraform/outputs.tf
+```hcl file=./_data/outputs.tf
 ```
 
 ### Example Variables File
 
 Copy `terraform.tfvars.example` to `terraform.tfvars` and fill in your values. The `.gitignore` excludes `terraform.tfvars` to prevent committing credentials:
 
-```hcl file=../terraform/terraform.tfvars.example
+```hcl file=./_data/terraform.tfvars.example
 ```
 
 Replace `subscription_id` with your Azure subscription ID (from `az account show --query id -o tsv`) and `target_fqdn` with your F5 XC load balancer domain.


### PR DESCRIPTION
Closes #9

## Summary
- Fixes all 7 `file=` import paths in `docs/03-deploy.mdx` from `../terraform/*.tf` to `./_data/*.tf`
- The docs-builder CI staging copies terraform files to `docs/_data/` (flat), so MDX must reference `./_data/` not `../terraform/`
- Without this fix, all terraform code blocks render as empty `<code></code>` on the published site and llms-full.txt shows raw `file=` directives instead of content

## Test plan
- [ ] After merge, verify `https://f5xc-salesdemos.github.io/traffic-generator/03-deploy/` shows actual HCL code in code blocks
- [ ] Verify `llms-full.txt` contains terraform content (grep for "terraform {" or "variable")

🤖 Generated with [Claude Code](https://claude.com/claude-code)