### PR TITLE
fix: mount terraform/ into docs-builder for DRY file= imports

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -19,5 +19,123 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docs:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/github-pages-deploy.yml@main
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stage imported files for documentation
+        run: |
+          CONTENT="docs"
+          IMPORTS="${CONTENT}/_imports"
+          DATA_DIR="${CONTENT}/_data"
+          if [ -f "$IMPORTS" ]; then
+            mkdir -p "$DATA_DIR"
+            while IFS= read -r file; do
+              [ -z "$file" ] || [ "${file:0:1}" = "#" ] && continue
+              if [ -f "$file" ]; then
+                cp "$file" "$DATA_DIR/"
+                echo "Staged: $file"
+              fi
+            done < "$IMPORTS"
+          fi
+
+      - name: Build docs with terraform mount
+        env:
+          DOCS_SITE: "https://f5xc-salesdemos.github.io"
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          mkdir -p "${{ runner.temp }}/docs-output"
+          chmod 777 "${{ runner.temp }}/docs-output"
+
+          docker run --rm \
+            --name docs-builder \
+            -v "${{ github.workspace }}/docs:/content/docs:ro" \
+            -v "${{ github.workspace }}/terraform:/content/terraform:ro" \
+            -v "${{ runner.temp }}/docs-output:/output" \
+            -e CONTENT_DIR=/content/docs \
+            -e OUTPUT_DIR=/output \
+            -e DOCS_SITE="${DOCS_SITE}" \
+            -e GITHUB_REPOSITORY="${GITHUB_REPO}" \
+            ghcr.io/f5xc-salesdemos/docs-builder:latest
+
+          echo "Build completed"
+          ls -lah "${{ runner.temp }}/docs-output/"
+
+      - name: Verify build output
+        run: |
+          OUTPUT_DIR="${{ runner.temp }}/docs-output"
+          if [ ! -d "$OUTPUT_DIR" ] || [ -z "$(ls -A $OUTPUT_DIR)" ]; then
+            echo "Build output is empty"
+            exit 1
+          fi
+          echo "Build output verified"
+
+      - name: Stage governance assets
+        run: |
+          OUTPUT_DIR="${{ runner.temp }}/docs-output"
+          API_DIR="${OUTPUT_DIR}/api"
+          mkdir -p "${API_DIR}/files"
+
+          for src in \
+              .github/config/repo-settings.json \
+              .github/config/managed-files-manifest.json \
+              .github/config/docs-sites.json \
+              README.md.tpl; do
+            [ -f "$src" ] || continue
+            dest="${API_DIR}/$(basename "$src")"
+            cp "$src" "$dest"
+            echo "Published: /api/$(basename "$src")"
+          done
+
+          MANIFEST=".github/config/managed-files-manifest.json"
+          if [ -f "$MANIFEST" ]; then
+            mapfile -t FILES < <(jq -r '.files | keys[]' "$MANIFEST")
+            for dest in "${FILES[@]}"; do
+              if [ -f "$dest" ]; then
+                target="${API_DIR}/files/${dest}"
+                mkdir -p "$(dirname "$target")"
+                cp "$dest" "$target"
+                echo "Published: /api/files/${dest}"
+              fi
+            done
+          fi
+
+          jq -n \
+            --arg commit "${GITHUB_SHA}" \
+            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{commit:$commit, generated_at:$generated_at}' \
+            > "${API_DIR}/revision.json"
+
+          touch "${OUTPUT_DIR}/.nojekyll"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: ${{ runner.temp }}/docs-output
+          retention-days: 1
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: success()
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -20,26 +20,26 @@ cp terraform.tfvars.example terraform.tfvars
 
 `main.tf` configures the Azure provider:
 
-```hcl file=./_data/main.tf
+```hcl file=../terraform/main.tf
 ```
 
 `variables.tf` defines all configurable parameters. The `vm_size` default is `Standard_F16s_v2` (16 vCPU compute-optimized) — see [VM Sizing](#vm-sizing) for scaling guidance:
 
-```hcl file=./_data/variables.tf
+```hcl file=../terraform/variables.tf
 ```
 
 ### Network Infrastructure
 
 `network.tf` creates the VNet, subnet, public IP, NSG (port 22 SSH), and NIC:
 
-```hcl file=./_data/network.tf
+```hcl file=../terraform/network.tf
 ```
 
 ### Virtual Machine with Cloud-Init
 
 `vm.tf` creates the Ubuntu 24.04 VM and passes the cloud-init template with target and tooling variables:
 
-```hcl file=./_data/vm.tf
+```hcl file=../terraform/vm.tf
 ```
 
 ### Cloud-Init Provisioning
@@ -59,21 +59,21 @@ cp terraform.tfvars.example terraform.tfvars
 
 The cloud-init uses Terraform template variables: `${target_fqdn}`, `${target_origin_ip}`, and `${tool_tier}`. Shell variables like `$NPROC` are escaped as `$$NPROC` in the Terraform templatefile.
 
-```yaml file=./_data/cloud-init.yaml
+```yaml file=../terraform/cloud-init.yaml
 ```
 
 ### Outputs
 
 `outputs.tf` exposes the public IP, SSH command, target FQDN, status check, and resource group:
 
-```hcl file=./_data/outputs.tf
+```hcl file=../terraform/outputs.tf
 ```
 
 ### Example Variables File
 
 Copy `terraform.tfvars.example` to `terraform.tfvars` and fill in your values. The `.gitignore` excludes `terraform.tfvars` to prevent committing credentials:
 
-```hcl file=./_data/terraform.tfvars.example
+```hcl file=../terraform/terraform.tfvars.example
 ```
 
 Replace `subscription_id` with your Azure subscription ID (from `az account show --query id -o tsv`) and `target_fqdn` with your F5 XC load balancer domain.


### PR DESCRIPTION
Closes #9
Closes #11

## Summary
- Replaces the reusable docs-control workflow with a custom build job that adds a second Docker volume mount: `-v terraform:/content/terraform:ro`
- From `/content/docs/03-deploy.mdx`, `file=../terraform/main.tf` now resolves to `/content/terraform/main.tf` which exists inside the container
- Reverts `file=` paths from `_data/` back to `../terraform/` — the natural relative path from the MDX file to the terraform source
- `terraform/` files remain the **single source of truth** — docs render them via import, no duplication

## Root cause
The reusable workflow only mounts `docs/` into the Docker container. The `_imports` staging copies files to `docs/_data/` (flat), but remark-code-import resolves paths relative to the MDX file's `dirname`. Neither `../terraform/` (outside the mount) nor `./_data/` (Expressive Code conflict) resulted in content injection.

## Test plan
- [ ] After merge, verify `curl -sL .../03-deploy/ | grep -c "azurerm"` returns > 0
- [ ] Verify `curl -sL .../llms-full.txt | grep -c "terraform {"` returns > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)