### PR TITLE
feat: add component manifest for progressive discovery

### DIFF
--- a/component-manifest.json
+++ b/component-manifest.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "1",
+  "name": "traffic-generator",
+  "role": "Attack traffic and legitimate traffic generation VM",
+  "category": "lab-infrastructure",
+  "summary": "Azure Ubuntu 24.04 VM with 50+ security testing tools and 7 pre-built attack suites for generating WAF, API, bot, reconnaissance, SSL, and JavaScript exploit traffic against F5 Distributed Cloud protected applications",
+  "provides": ["attack-traffic", "legitimate-traffic", "security-scanning", "api-fuzzing", "bot-simulation"],
+  "pairs_with": ["origin-server", "cdn-simulator"],
+  "demos": ["waf", "api-security", "bot-standard", "bot-advanced", "ddos", "was"],
+  "terraform": {
+    "required_vars": ["subscription_id", "target_fqdn"],
+    "vm_size": "Standard_F16s_v2",
+    "estimated_monthly_cost": "$389"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `component-manifest.json` defining the traffic-generator component metadata for progressive discovery by xcsh
- Biome-formatted JSON with component name, version, type, and discovery metadata

Closes #17

## Test plan

- [x] Pre-commit hooks pass (including Biome lint)
- [ ] CI checks pass (`Check linked issues` and `Lint Code Base`)