### PR TITLE
feat: deployer variable for unique resource group names per SE

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,3 +13,7 @@ provider "azurerm" {
   features {}
   subscription_id = var.subscription_id
 }
+
+locals {
+  resource_group_name = var.resource_group_name != "" ? var.resource_group_name : "rg-traffic-generator-${var.deployer}"
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "traffic_gen" {
-  name     = var.resource_group_name
+  name     = local.resource_group_name
   location = var.location
 
   tags = {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -20,5 +20,5 @@ output "status_check" {
 
 output "resource_group" {
   description = "Resource group containing all traffic generator resources"
-  value       = azurerm_resource_group.traffic_gen.name
+  value       = local.resource_group_name
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,5 +1,7 @@
 subscription_id    = "00000000-0000-0000-0000-000000000000"
 target_fqdn        = "demo.example.com"
+deployer           = "robin"           # your initials or first name → rg-traffic-generator-robin
+# resource_group_name = ""            # leave blank to auto-generate from deployer
 # target_origin_ip = "10.0.0.4"
 # tool_tier        = "full"
 # vm_size          = "Standard_F16s_v2"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,10 +3,20 @@ variable "subscription_id" {
   type        = string
 }
 
-variable "resource_group_name" {
-  description = "Name for the Azure resource group"
+variable "deployer" {
+  description = "Short identifier for the person deploying (e.g. initials or first name). Appended to the resource group name to avoid collisions in shared subscriptions."
   type        = string
-  default     = "rg-traffic-generator"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{2,12}$", var.deployer))
+    error_message = "deployer must be 2-12 lowercase alphanumeric characters."
+  }
+}
+
+variable "resource_group_name" {
+  description = "Name for the Azure resource group (auto-generated from deployer if not set)"
+  type        = string
+  default     = ""
 }
 
 variable "location" {


### PR DESCRIPTION
Closes #21

## Problem
Multiple SEs deploying into the same Azure subscription collide on the hardcoded resource group name \`rg-traffic-generator\`. Terraform fails on the second deployment.

## Root cause analysis
Only the **resource group name** must be unique per subscription. All other resources (VNet, NIC, NSG, PIP, VM) are scoped to the resource group — they can keep hardcoded names as long as each SE gets a unique RG.

## Solution
Add a required \`deployer\` variable (2–12 lowercase alphanumeric). The RG name auto-generates as \`rg-traffic-generator-{deployer}\`:

| SE | Resource Group |
|---|---|
| robin | \`rg-traffic-generator-robin\` |
| dave | \`rg-traffic-generator-dave\` |
| jsmith | \`rg-traffic-generator-jsmith\` |

\`resource_group_name\` still works as an explicit override for advanced use.

## Changes
- `variables.tf`: add `deployer` variable with regex validation, set `resource_group_name` default to `""`
- `main.tf`: add `locals` block — `rg-traffic-generator-${var.deployer}` or explicit override
- `network.tf`: use `local.resource_group_name` instead of `var.resource_group_name`
- `outputs.tf`: surface the actual RG name used
- `terraform.tfvars.example`: document `deployer = "robin"`

## Test plan
- [ ] `terraform validate` passes
- [ ] `terraform fmt -check` passes
- [ ] Two SEs with different `deployer` values deploy without collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)