### PR TITLE
feat(terraform): standardize terraform per Demo Resource Standard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,20 @@ repos:
         args: ["--branch", "main"]
 
   # ===========================================================================
+  # Terraform formatting and validation
+  # ===========================================================================
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.96.1
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_docs
+        args:
+          - --hook-config=--path-to-file=README.md
+          - --hook-config=--add-to-existing-file=true
+          - --args=--config=.terraform-docs.yml
+
+  # ===========================================================================
   # Repository-specific hooks (escape hatch)
   #
   # Runs scripts/pre-commit-local.sh if present and executable. Repos use
@@ -204,3 +218,6 @@ ci:
     - zizmor
     - checkov
     - gitleaks
+    - terraform_fmt
+    - terraform_validate
+    - terraform_docs

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,19 @@
+formatter: markdown table
+
+content: ""
+
+output:
+  file: ../README.md
+  mode: inject
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  anchor: true
+  escape: true
+  indent: 2
+  required: true
+  sensitive: true
+  type: true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,83 @@
 See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow rules,
 branch naming, and CI requirements.
 
+## Terraform Reference
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.8.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.71.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [azurerm_linux_virtual_machine.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine) | resource |
+| [azurerm_network_interface.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) | resource |
+| [azurerm_network_interface_security_group_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_security_group_association) | resource |
+| [azurerm_network_security_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
+| [azurerm_public_ip.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_subnet.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_virtual_network.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
+| [azuread_user.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Azure subscription ID | `string` | n/a | yes |
+| <a name="input_target_fqdn"></a> [target\_fqdn](#input\_target\_fqdn) | FQDN of the F5 XC load balancer to target | `string` | n/a | yes |
+| <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | SSH admin username for the VM | `string` | `"azureuser"` | no |
+| <a name="input_deployer"></a> [deployer](#input\_deployer) | Override for deployer identifier (auto-resolved from Azure AD if empty). Required for service principal or managed identity authentication. | `string` | `""` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | OS disk size in GB | `number` | `64` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment label used in resource group naming and tags | `string` | `"lab"` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure region for all resources | `string` | `"eastus2"` | no |
+| <a name="input_ssh_public_key_path"></a> [ssh\_public\_key\_path](#input\_ssh\_public\_key\_path) | Path to the SSH public key file | `string` | `"~/.ssh/id_ed25519.pub"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags merged with standard tags (component, environment, deployer, managed\_by) | `map(string)` | `{}` | no |
+| <a name="input_target_origin_ip"></a> [target\_origin\_ip](#input\_target\_origin\_ip) | Direct origin IP for bypass testing | `string` | `""` | no |
+| <a name="input_tool_tier"></a> [tool\_tier](#input\_tool\_tier) | Tool installation tier: standard (default) or full (includes ZAP, Metasploit) | `string` | `"standard"` | no |
+| <a name="input_vm_size"></a> [vm\_size](#input\_vm\_size) | Azure VM size (F16s\_v2: 16 vCPU compute-optimized, validated by benchmark) | `string` | `"Standard_F16s_v2"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_component"></a> [component](#output\_component) | Component name |
+| <a name="output_deployer"></a> [deployer](#output\_deployer) | Resolved deployer identifier |
+| <a name="output_environment"></a> [environment](#output\_environment) | Environment label |
+| <a name="output_location"></a> [location](#output\_location) | Azure region |
+| <a name="output_nsg_id"></a> [nsg\_id](#output\_nsg\_id) | Resource ID of the network security group |
+| <a name="output_nsg_name"></a> [nsg\_name](#output\_nsg\_name) | Name of the network security group |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | Private IP address of the VM |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | Public IP address of the VM |
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | Resource ID of the resource group |
+| <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | Name of the resource group |
+| <a name="output_ssh_command"></a> [ssh\_command](#output\_ssh\_command) | SSH command to connect to the VM |
+| <a name="output_status_check"></a> [status\_check](#output\_status\_check) | SSH command to check provisioning status |
+| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | Resource ID of the subnet |
+| <a name="output_target_fqdn"></a> [target\_fqdn](#output\_target\_fqdn) | Target FQDN the traffic generator is configured to attack |
+| <a name="output_vm_id"></a> [vm\_id](#output\_vm\_id) | Resource ID of the virtual machine |
+| <a name="output_vm_name"></a> [vm\_name](#output\_vm\_name) | Name of the virtual machine |
+| <a name="output_vnet_name"></a> [vnet\_name](#output\_vnet\_name) | Name of the virtual network |
+<!-- END_TF_DOCS -->
+
 ## License
 
 See [LICENSE](LICENSE).

--- a/component-manifest.json
+++ b/component-manifest.json
@@ -1,15 +1,130 @@
 {
-  "schema_version": "1",
+  "schema_version": "2",
   "name": "traffic-generator",
+  "display_name": "Traffic Generator",
   "role": "Attack traffic and legitimate traffic generation VM",
   "category": "lab-infrastructure",
   "summary": "Azure Ubuntu 24.04 VM with 50+ security testing tools and 7 pre-built attack suites for generating WAF, API, bot, reconnaissance, SSL, and JavaScript exploit traffic against F5 Distributed Cloud protected applications",
+
   "provides": ["attack-traffic", "legitimate-traffic", "security-scanning", "api-fuzzing", "bot-simulation"],
   "pairs_with": ["origin-server", "cdn-simulator"],
   "demos": ["waf", "api-security", "bot-standard", "bot-advanced", "ddos", "was"],
+
   "terraform": {
-    "required_vars": ["subscription_id", "target_fqdn"],
-    "vm_size": "Standard_F16s_v2",
-    "estimated_monthly_cost": "$389"
+    "required_inputs": {
+      "subscription_id": {
+        "type": "string",
+        "description": "Azure subscription ID"
+      },
+      "target_fqdn": {
+        "type": "string",
+        "description": "FQDN of the F5 XC load balancer to target"
+      }
+    },
+    "optional_inputs": {
+      "deployer": {
+        "type": "string",
+        "default": "",
+        "description": "Override for deployer identifier (auto-resolved from Azure AD if empty)"
+      },
+      "location": {
+        "type": "string",
+        "default": "eastus2",
+        "description": "Azure region for all resources"
+      },
+      "environment": {
+        "type": "string",
+        "default": "lab",
+        "description": "Environment label used in resource group naming and tags"
+      },
+      "vm_size": {
+        "type": "string",
+        "default": "Standard_F16s_v2",
+        "description": "Azure VM size (F16s_v2: 16 vCPU compute-optimized)"
+      },
+      "disk_size_gb": {
+        "type": "number",
+        "default": 64,
+        "description": "OS disk size in GB"
+      },
+      "admin_username": {
+        "type": "string",
+        "default": "azureuser",
+        "description": "SSH admin username for the VM"
+      },
+      "ssh_public_key_path": {
+        "type": "string",
+        "default": "~/.ssh/id_ed25519.pub",
+        "description": "Path to the SSH public key file"
+      },
+      "tags": {
+        "type": "map(string)",
+        "default": {},
+        "description": "Additional tags merged with standard tags"
+      },
+      "target_origin_ip": {
+        "type": "string",
+        "default": "",
+        "description": "Direct origin IP for bypass testing"
+      },
+      "tool_tier": {
+        "type": "string",
+        "default": "standard",
+        "description": "Tool installation tier: standard or full (includes ZAP, Metasploit)"
+      }
+    },
+    "standard_outputs": [
+      "deployer",
+      "resource_group_name",
+      "resource_group_id",
+      "location",
+      "public_ip",
+      "private_ip",
+      "ssh_command",
+      "vm_name",
+      "vm_id",
+      "nsg_name",
+      "nsg_id",
+      "vnet_name",
+      "subnet_id",
+      "component",
+      "environment"
+    ],
+    "component_outputs": {
+      "target_fqdn": {
+        "type": "string",
+        "description": "Target FQDN the traffic generator is configured to attack"
+      },
+      "status_check": {
+        "type": "string",
+        "description": "SSH command to check provisioning status"
+      }
+    },
+    "estimated_monthly_cost": "$389",
+    "vm_image": {
+      "publisher": "Canonical",
+      "offer": "ubuntu-24_04-lts",
+      "sku": "server",
+      "version": "latest"
+    }
+  },
+
+  "nsg_rules": [
+    {
+      "name": "AllowSSH",
+      "priority": 100,
+      "direction": "Inbound",
+      "access": "Allow",
+      "protocol": "Tcp",
+      "destination_port_range": "22",
+      "source_address_prefix": "*",
+      "description": "SSH access for administration"
+    }
+  ],
+
+  "health_check": {
+    "path": null,
+    "port": null,
+    "expected_status": null
   }
 }

--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -2,7 +2,7 @@
   "customSets": [
     {
       "label": "Deployment",
-      "description": "Terraform IaC deployment with all configuration files",
+      "description": "Terraform IaC deployment with prerequisites and teardown",
       "paths": ["02-prerequisites*", "03-deploy*", "08-teardown*"]
     },
     {

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,6 @@
+data "azuread_client_config" "current" {}
+
+data "azuread_user" "current" {
+  count     = var.deployer == "" ? 1 : 0
+  object_id = data.azuread_client_config.current.object_id
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,58 @@
+locals {
+  component = "traffic-generator"
+
+  # --- Deployer resolution (4-tier fallback) ---
+  # 1. Explicit override via var.deployer
+  # 2a. Azure AD: given_name initial + surname
+  # 2b. Azure AD: mail prefix (guest/external accounts)
+  # 3. Object ID hash (service principals, managed identities)
+  deployer_from_name = (
+    var.deployer == "" && length(data.azuread_user.current) > 0
+    ? try(
+      lower("${substr(data.azuread_user.current[0].given_name, 0, 1)}${data.azuread_user.current[0].surname}"),
+      ""
+    )
+    : ""
+  )
+
+  deployer_from_mail = (
+    var.deployer == "" && length(data.azuread_user.current) > 0 && local.deployer_from_name == ""
+    ? try(
+      lower(split("@", data.azuread_user.current[0].mail)[0]),
+      ""
+    )
+    : ""
+  )
+
+  deployer_from_oid = substr(sha1(data.azuread_client_config.current.object_id), 0, 8)
+
+  deployer_resolved = coalesce(
+    var.deployer,
+    local.deployer_from_name,
+    local.deployer_from_mail,
+    local.deployer_from_oid
+  )
+
+  deployer = replace(lower(local.deployer_resolved), "/[^a-z0-9]/", "")
+
+  # --- Resource naming (Cloud Adoption Framework) ---
+  name = {
+    resource_group    = "rg-${local.component}-${var.environment}-${local.deployer}"
+    virtual_network   = "vnet-${local.component}-${local.deployer}"
+    subnet            = "snet-${local.component}-${local.deployer}"
+    public_ip         = "pip-${local.component}-${local.deployer}"
+    nsg               = "nsg-${local.component}-${local.deployer}"
+    network_interface = "nic-${local.component}-${local.deployer}"
+    virtual_machine   = "vm-${local.component}-${local.deployer}"
+  }
+
+  # --- Standard tags ---
+  standard_tags = {
+    component   = local.component
+    environment = var.environment
+    deployer    = local.deployer
+    managed_by  = "terraform"
+  }
+
+  tags = merge(local.standard_tags, var.tags)
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,19 +1,5 @@
-terraform {
-  required_version = ">= 1.5.0"
-
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
-    }
-  }
-}
-
-provider "azurerm" {
-  features {}
-  subscription_id = var.subscription_id
-}
-
-locals {
-  resource_group_name = var.resource_group_name != "" ? var.resource_group_name : "rg-traffic-generator-${var.deployer}"
+resource "azurerm_resource_group" "main" {
+  name     = local.name.resource_group
+  location = var.location
+  tags     = local.tags
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,43 +1,33 @@
-resource "azurerm_resource_group" "traffic_gen" {
-  name     = local.resource_group_name
-  location = var.location
-
-  tags = {
-    environment = var.environment_tag
-    component   = "traffic-generator"
-  }
-}
-
-resource "azurerm_virtual_network" "traffic_gen" {
-  name                = "vnet-traffic-generator"
+resource "azurerm_virtual_network" "main" {
+  name                = local.name.virtual_network
   address_space       = ["10.201.0.0/16"]
-  location            = azurerm_resource_group.traffic_gen.location
-  resource_group_name = azurerm_resource_group.traffic_gen.name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 
-  tags = azurerm_resource_group.traffic_gen.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_subnet" "traffic_gen" {
-  name                 = "snet-traffic-generator"
-  resource_group_name  = azurerm_resource_group.traffic_gen.name
-  virtual_network_name = azurerm_virtual_network.traffic_gen.name
+resource "azurerm_subnet" "main" {
+  name                 = local.name.subnet
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.201.1.0/24"]
 }
 
-resource "azurerm_public_ip" "traffic_gen" {
-  name                = "pip-traffic-generator"
-  location            = azurerm_resource_group.traffic_gen.location
-  resource_group_name = azurerm_resource_group.traffic_gen.name
+resource "azurerm_public_ip" "main" {
+  name                = local.name.public_ip
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
   allocation_method   = "Static"
   sku                 = "Standard"
 
-  tags = azurerm_resource_group.traffic_gen.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_network_security_group" "traffic_gen" {
-  name                = "nsg-traffic-generator"
-  location            = azurerm_resource_group.traffic_gen.location
-  resource_group_name = azurerm_resource_group.traffic_gen.name
+resource "azurerm_network_security_group" "main" {
+  name                = local.name.nsg
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 
   security_rule {
     name                       = "AllowSSH"
@@ -51,25 +41,25 @@ resource "azurerm_network_security_group" "traffic_gen" {
     destination_address_prefix = "*"
   }
 
-  tags = azurerm_resource_group.traffic_gen.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_network_interface" "traffic_gen" {
-  name                = "nic-traffic-generator"
-  location            = azurerm_resource_group.traffic_gen.location
-  resource_group_name = azurerm_resource_group.traffic_gen.name
+resource "azurerm_network_interface" "main" {
+  name                = local.name.network_interface
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 
   ip_configuration {
     name                          = "internal"
-    subnet_id                     = azurerm_subnet.traffic_gen.id
+    subnet_id                     = azurerm_subnet.main.id
     private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = azurerm_public_ip.traffic_gen.id
+    public_ip_address_id          = azurerm_public_ip.main.id
   }
 
-  tags = azurerm_resource_group.traffic_gen.tags
+  tags = azurerm_resource_group.main.tags
 }
 
-resource "azurerm_network_interface_security_group_association" "traffic_gen" {
-  network_interface_id      = azurerm_network_interface.traffic_gen.id
-  network_security_group_id = azurerm_network_security_group.traffic_gen.id
+resource "azurerm_network_interface_security_group_association" "main" {
+  network_interface_id      = azurerm_network_interface.main.id
+  network_security_group_id = azurerm_network_security_group.main.id
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,12 +1,85 @@
+# ---------------------------------------------------------
+# Standard Outputs (present in every demo resource)
+# ---------------------------------------------------------
+
+output "deployer" {
+  description = "Resolved deployer identifier"
+  value       = local.deployer
+}
+
+output "resource_group_name" {
+  description = "Name of the resource group"
+  value       = azurerm_resource_group.main.name
+}
+
+output "resource_group_id" {
+  description = "Resource ID of the resource group"
+  value       = azurerm_resource_group.main.id
+}
+
+output "location" {
+  description = "Azure region"
+  value       = azurerm_resource_group.main.location
+}
+
 output "public_ip" {
-  description = "Public IP address of the traffic generator VM"
-  value       = azurerm_public_ip.traffic_gen.ip_address
+  description = "Public IP address of the VM"
+  value       = azurerm_public_ip.main.ip_address
+}
+
+output "private_ip" {
+  description = "Private IP address of the VM"
+  value       = azurerm_network_interface.main.private_ip_address
 }
 
 output "ssh_command" {
-  description = "SSH command to connect to the traffic generator"
-  value       = "ssh ${var.admin_username}@${azurerm_public_ip.traffic_gen.ip_address}"
+  description = "SSH command to connect to the VM"
+  value       = "ssh ${var.admin_username}@${azurerm_public_ip.main.ip_address}"
 }
+
+output "vm_name" {
+  description = "Name of the virtual machine"
+  value       = azurerm_linux_virtual_machine.main.name
+}
+
+output "vm_id" {
+  description = "Resource ID of the virtual machine"
+  value       = azurerm_linux_virtual_machine.main.id
+}
+
+output "nsg_name" {
+  description = "Name of the network security group"
+  value       = azurerm_network_security_group.main.name
+}
+
+output "nsg_id" {
+  description = "Resource ID of the network security group"
+  value       = azurerm_network_security_group.main.id
+}
+
+output "vnet_name" {
+  description = "Name of the virtual network"
+  value       = azurerm_virtual_network.main.name
+}
+
+output "subnet_id" {
+  description = "Resource ID of the subnet"
+  value       = azurerm_subnet.main.id
+}
+
+output "component" {
+  description = "Component name"
+  value       = local.component
+}
+
+output "environment" {
+  description = "Environment label"
+  value       = var.environment
+}
+
+# ---------------------------------------------------------
+# Component-Specific Outputs
+# ---------------------------------------------------------
 
 output "target_fqdn" {
   description = "Target FQDN the traffic generator is configured to attack"
@@ -15,10 +88,5 @@ output "target_fqdn" {
 
 output "status_check" {
   description = "SSH command to check provisioning status"
-  value       = "ssh ${var.admin_username}@${azurerm_public_ip.traffic_gen.ip_address} cat /opt/traffic-generator/status.json"
-}
-
-output "resource_group" {
-  description = "Resource group containing all traffic generator resources"
-  value       = local.resource_group_name
+  value       = "ssh ${var.admin_username}@${azurerm_public_ip.main.ip_address} cat /opt/traffic-generator/status.json"
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,6 @@
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+provider "azuread" {}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,8 +1,18 @@
-subscription_id    = "00000000-0000-0000-0000-000000000000"
-target_fqdn        = "demo.example.com"
-deployer           = "robin"           # your initials or first name → rg-traffic-generator-robin
-# resource_group_name = ""            # leave blank to auto-generate from deployer
-# target_origin_ip = "10.0.0.4"
-# tool_tier        = "full"
-# vm_size          = "Standard_F16s_v2"
-# disk_size_gb     = 128
+# Copy this file to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored — never commit real credentials.
+
+# --- Required ---
+subscription_id = "00000000-0000-0000-0000-000000000000"
+target_fqdn     = "demo.example.com"
+
+# --- Optional overrides (defaults shown) ---
+# deployer            = ""                       # auto-resolved from Azure AD
+# location            = "eastus2"
+# environment         = "lab"
+# vm_size             = "Standard_F16s_v2"
+# disk_size_gb        = 64
+# admin_username      = "azureuser"
+# ssh_public_key_path = "~/.ssh/id_ed25519.pub"
+# tags                = {}
+# target_origin_ip    = ""
+# tool_tier           = "standard"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,20 +1,14 @@
+# ---------------------------------------------------------
+# General
+# ---------------------------------------------------------
+
 variable "subscription_id" {
   description = "Azure subscription ID"
   type        = string
 }
 
 variable "deployer" {
-  description = "Short identifier for the person deploying (e.g. initials or first name). Appended to the resource group name to avoid collisions in shared subscriptions."
-  type        = string
-
-  validation {
-    condition     = can(regex("^[a-z0-9]{2,12}$", var.deployer))
-    error_message = "deployer must be 2-12 lowercase alphanumeric characters."
-  }
-}
-
-variable "resource_group_name" {
-  description = "Name for the Azure resource group (auto-generated from deployer if not set)"
+  description = "Override for deployer identifier (auto-resolved from Azure AD if empty). Required for service principal or managed identity authentication."
   type        = string
   default     = ""
 }
@@ -25,8 +19,24 @@ variable "location" {
   default     = "eastus2"
 }
 
+variable "environment" {
+  description = "Environment label used in resource group naming and tags"
+  type        = string
+  default     = "lab"
+}
+
+variable "tags" {
+  description = "Additional tags merged with standard tags (component, environment, deployer, managed_by)"
+  type        = map(string)
+  default     = {}
+}
+
+# ---------------------------------------------------------
+# Compute
+# ---------------------------------------------------------
+
 variable "vm_size" {
-  description = "Azure VM size (F16s_v2: 16 vCPU compute-optimized — best throughput per dollar, validated by A/B/C/D benchmark)"
+  description = "Azure VM size (F16s_v2: 16 vCPU compute-optimized, validated by benchmark)"
   type        = string
   default     = "Standard_F16s_v2"
 }
@@ -43,14 +53,18 @@ variable "ssh_public_key_path" {
   default     = "~/.ssh/id_ed25519.pub"
 }
 
-variable "environment_tag" {
-  description = "Environment tag applied to all resources"
-  type        = string
-  default     = "lab"
+variable "disk_size_gb" {
+  description = "OS disk size in GB"
+  type        = number
+  default     = 64
 }
 
+# ---------------------------------------------------------
+# Component-Specific
+# ---------------------------------------------------------
+
 variable "target_fqdn" {
-  description = "FQDN of the F5 XC load balancer to attack"
+  description = "FQDN of the F5 XC load balancer to target"
   type        = string
 }
 
@@ -58,12 +72,6 @@ variable "target_origin_ip" {
   description = "Direct origin IP for bypass testing"
   type        = string
   default     = ""
-}
-
-variable "disk_size_gb" {
-  description = "OS disk size in GB (larger disk for security tools)"
-  type        = number
-  default     = 64
 }
 
 variable "tool_tier" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/terraform/vm.tf
+++ b/terraform/vm.tf
@@ -1,7 +1,7 @@
-resource "azurerm_linux_virtual_machine" "traffic_gen" {
-  name                = "vm-traffic-generator"
-  resource_group_name = azurerm_resource_group.traffic_gen.name
-  location            = azurerm_resource_group.traffic_gen.location
+resource "azurerm_linux_virtual_machine" "main" {
+  name                = local.name.virtual_machine
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
   size                = var.vm_size
 
   admin_username                  = var.admin_username
@@ -9,10 +9,10 @@ resource "azurerm_linux_virtual_machine" "traffic_gen" {
 
   admin_ssh_key {
     username   = var.admin_username
-    public_key = file(var.ssh_public_key_path)
+    public_key = file(pathexpand(var.ssh_public_key_path))
   }
 
-  network_interface_ids = [azurerm_network_interface.traffic_gen.id]
+  network_interface_ids = [azurerm_network_interface.main.id]
 
   os_disk {
     caching              = "ReadWrite"
@@ -33,5 +33,5 @@ resource "azurerm_linux_virtual_machine" "traffic_gen" {
     tool_tier        = var.tool_tier
   }))
 
-  tags = azurerm_resource_group.traffic_gen.tags
+  tags = azurerm_resource_group.main.tags
 }


### PR DESCRIPTION
## Summary

- Split `main.tf` into `versions.tf`, `providers.tf`, `data.tf`, `locals.tf` (resource group stays in `main.tf`)
- Add `azuread` provider for automatic deployer name resolution (4-tier fallback: explicit → given_name/surname → mail prefix → object ID hash)
- Adopt Azure CAF naming (`rg-traffic-generator-lab-rmordasiewicz`, `vm-traffic-generator-rmordasiewicz`)
- Rename all HCL resource labels from `traffic_gen` to `main`
- Standardize variables: `deployer` now optional with Azure AD auto-resolve, `environment_tag` → `environment`, remove `resource_group_name`, add `tags`
- Expand outputs from 5 to 17 (15 standard + 2 component-specific)
- Add `pathexpand()` for SSH key path
- Upgrade `component-manifest.json` to schema v2
- Add `.terraform-docs.yml` and auto-generated Terraform Reference in README
- Add `terraform_fmt`, `terraform_validate`, `terraform_docs` pre-commit hooks

Closes #39

## Test plan

- [x] `terraform fmt -check` passes
- [x] `terraform validate` passes
- [x] `terraform plan` succeeds with live Azure AD credentials
- [x] Deployer resolves to `rmordasiewicz`
- [x] Resource group: `rg-traffic-generator-lab-rmordasiewicz`
- [x] All 17 outputs present
- [x] Tags include all 4 standard keys
- [x] `component-manifest.json` validates as schema v2 with 15 standard outputs
- [x] All pre-commit hooks pass