### PR TITLE
fix(cloud-init): fix hey and vegeta install — S3 403, wrong arch mapping

### DIFF
--- a/terraform/cloud-init.yaml
+++ b/terraform/cloud-init.yaml
@@ -275,18 +275,14 @@ runcmd:
     export DPKG_ARCH=$(dpkg --print-architecture)
     export PATH=/usr/local/bin:$PATH
 
-    echo "Installing hey..."
-    curl -fsSL "https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_$${DPKG_ARCH}" -o /usr/local/bin/hey && chmod +x /usr/local/bin/hey || echo "hey S3 download failed, trying go install..."
-    if ! command -v hey >/dev/null 2>&1; then
-      apt-get install -y golang-go
-      GOPATH=/opt/go go install github.com/rakyll/hey@latest
-      cp /opt/go/bin/hey /usr/local/bin/hey
-    fi
+    echo "Installing hey (via go install — no prebuilt binaries available)..."
+    apt-get install -y golang-go
+    GOPATH=/opt/go go install github.com/rakyll/hey@latest
+    cp /opt/go/bin/hey /usr/local/bin/hey
 
     echo "Installing vegeta..."
     VEGETA_VER=$(ghlatest tsenart/vegeta)
-    if [ "$DPKG_ARCH" = "amd64" ]; then VA="64bit"; else VA="$DPKG_ARCH"; fi
-    curl -fsSL "https://github.com/tsenart/vegeta/releases/download/v$${VEGETA_VER}/vegeta_$${VEGETA_VER}_linux_$${VA}.tar.gz" | tar -xz -C /usr/local/bin vegeta
+    curl -fsSL "https://github.com/tsenart/vegeta/releases/download/v$${VEGETA_VER}/vegeta_$${VEGETA_VER}_linux_$${DPKG_ARCH}.tar.gz" | tar -xz -C /usr/local/bin vegeta
 
     echo "Phase 3b complete"
 


### PR DESCRIPTION
## Summary

Fixes two tool install failures discovered during QA deployment testing:

- **hey**: S3 bucket URL (`hey-release.s3.us-east-2.amazonaws.com`) returns 403 Forbidden. No prebuilt binaries on GitHub Releases. Changed to `go install github.com/rakyll/hey@latest` as primary install method.
- **vegeta**: Architecture mapping `if amd64 then 64bit` is wrong — vegeta releases use `amd64` not `64bit`. Removed the mapping, now uses `$DPKG_ARCH` directly which matches release asset naming.

Closes #41

## Test plan

- [x] Verified hey S3 URL returns 403 Forbidden
- [x] Verified vegeta release assets use `amd64` naming (not `64bit`)
- [x] Deployed VM, provisioning completed with 24/27 tools passing → should now be 26+/27
- [x] `terraform validate` passes