### PR TITLE
docs: rewrite for 17 suites, terraform standardization, remove pricing

### DIFF
--- a/docs/01-architecture.mdx
+++ b/docs/01-architecture.mdx
@@ -24,7 +24,7 @@ graph LR
     TG[Traffic Generator VM<br/>Ubuntu 24.04<br/>Standard_F16s_v2] -->|Attack Traffic<br/>HTTPS| XCHLB[F5 XC HTTP LB<br/>WAF / Bot Defense<br/>API Security / CSD]
     XCHLB -->|Filtered Traffic<br/>HTTP| ORIGIN[Origin Server VM<br/>nginx + Docker Apps]
     TG -->|Direct Baseline<br/>HTTP optional| ORIGIN
-    RUNNER[runner.sh] --> SUITES[7 Traffic Suites]
+    RUNNER[runner.sh] --> SUITES[17 Traffic Suites]
     SUITES --> TG
 ```
 
@@ -51,7 +51,7 @@ The Traffic Generator VM runs on Azure with:
 
 ## Tiered Installation
 
-The Traffic Generator supports two installation tiers controlled by the `install_tier` Terraform variable:
+The Traffic Generator supports two installation tiers controlled by the `tool_tier` Terraform variable:
 
 ### Standard Tier (default)
 
@@ -61,15 +61,7 @@ Installs all tools listed in the tool catalog except ZAP and Metasploit. Provisi
 
 Adds OWASP ZAP and Metasploit Framework on top of the standard tier. Provisioning takes approximately 25 minutes. These tools are large (ZAP ~500 MiB, Metasploit ~1 GiB) and are only needed for advanced vulnerability scanning demos.
 
-## Estimated Costs
-
-| Resource | SKU | Estimated Monthly Cost |
-|---|---|---|
-| Ubuntu 24.04 VM | Standard_F16s_v2 (16 vCPU, 32 GiB) | ~$375 USD |
-| Public IP | Standard, Static | ~$4 USD |
-| OS Disk | 64 GiB Premium SSD | ~$10 USD |
-| VNet + NSG | -- | No additional cost |
-| **Total** | | **~$389 USD/month** |
+See the Azure pricing calculator for current VM costs. The default Standard_F16s_v2 is a compute-optimized instance suitable for sustained traffic generation.
 
 :::tip
 Use `terraform destroy` when the lab is not in use to avoid ongoing charges. See [Teardown](../08-teardown/) for the procedure.

--- a/docs/02-prerequisites.mdx
+++ b/docs/02-prerequisites.mdx
@@ -15,7 +15,7 @@ An active Azure subscription with Contributor role or equivalent permissions to 
 - Virtual networks and subnets
 - Network security groups
 - Public IP addresses
-- Virtual machines (Standard_D4s_v3 -- 4 vCPU, 16 GiB RAM)
+- Virtual machines (Standard_F16s_v2 default)
 
 ### Azure CLI
 
@@ -77,20 +77,10 @@ Before deploying the Traffic Generator, you should have:
 
 The `target_fqdn` Terraform variable should be set to the F5 XC load balancer's public domain.
 
-## Resource Estimates
-
-| Resource | SKU | Estimated Monthly Cost |
-|---|---|---|
-| Ubuntu 24.04 VM | Standard_D4s_v3 (4 vCPU, 16 GiB) | ~$130 USD |
-| Public IP | Standard, Static | ~$4 USD |
-| OS Disk | 64 GiB Premium SSD | ~$10 USD |
-| VNet + NSG | -- | No additional cost |
-| **Total** | | **~$140 USD/month** |
-
 :::tip
 Use `terraform destroy` when the lab is not in use to avoid ongoing charges. See [Teardown](../08-teardown/) for the procedure.
 :::
 
 :::note
-Standard_D4s_v3 (16 GiB RAM) is recommended because several tools run concurrently during suite execution. Browser automation (Playwright, Puppeteer) with headless Chromium is the primary memory consumer. Standard_D2s_v3 (8 GiB) will work for non-browser suites but may be tight when running bot-simulation.
+Standard_F16s_v2 (32 GiB RAM) is the default because several tools run concurrently during suite execution. Browser automation (Playwright, Puppeteer) with headless Chromium is the primary memory consumer. Smaller F-series SKUs will work for non-browser suites but may be tight when running bot-simulation.
 :::

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -16,6 +16,20 @@ cp terraform.tfvars.example terraform.tfvars
 
 ## Terraform Configuration
 
+### Terraform File Structure
+
+The terraform directory contains 9 files following the Demo Resource Standard:
+
+- `versions.tf` -- Terraform and provider version constraints (azurerm ~> 4.0, azuread ~> 3.0)
+- `providers.tf` -- Azure RM and Azure AD provider configuration
+- `data.tf` -- Azure AD data sources for deployer auto-resolution
+- `locals.tf` -- Deployer resolution, Azure Cloud Adoption Framework resource naming, standard tags
+- `main.tf` -- Resource group (named `rg-traffic-generator-{environment}-{deployer}`)
+- `variables.tf` -- All input variables (2 required, 9 optional) with deployer auto-resolution via Azure AD
+- `network.tf` -- VNet (10.201.0.0/16), subnet, public IP, NSG (port 22 SSH), NIC
+- `vm.tf` -- Ubuntu 24.04 VM with cloud-init via templatefile()
+- `outputs.tf` -- 17 outputs: 15 standard outputs shared by all demo resources (deployer, public_ip, private_ip, ssh_command, resource_group_name, vm_name, nsg_name, vnet_name, subnet_id, component, environment, resource_group_id, vm_id, nsg_id, location) plus 2 component-specific outputs (target_fqdn, status_check)
+
 ### Provider and Variables
 
 `main.tf` configures the Azure provider:
@@ -23,7 +37,7 @@ cp terraform.tfvars.example terraform.tfvars
 ```hcl file=./_data/main.tf
 ```
 
-`variables.tf` defines all configurable parameters. The `vm_size` default is `Standard_F16s_v2` (16 vCPU compute-optimized) — see [VM Sizing](#vm-sizing) for scaling guidance:
+`variables.tf` defines all configurable parameters. The `vm_size` default is `Standard_F16s_v2` (16 vCPU compute-optimized) -- see [VM Sizing](#vm-sizing) for scaling guidance:
 
 ```hcl file=./_data/variables.tf
 ```
@@ -44,18 +58,18 @@ cp terraform.tfvars.example terraform.tfvars
 
 ### Cloud-Init Provisioning
 
-`cloud-init.yaml` is the production-validated configuration verified under 48+ hours of continuous load testing including 4 rounds of origin torture testing. It provisions:
+`cloud-init.yaml` is the production-validated configuration verified under 48+ hours of continuous load testing including 4 rounds of origin torture testing. It uses a helper library with retry logic, progress logging to `/var/log/cloud-init-progress.log`, 9 provisioning phases, and conditional status reporting (ready/degraded in `status.json`). It provisions:
 
-- **Kernel tuning** — `somaxconn=131072`, `tcp_max_tw_buckets=4000000`, `tcp_fin_timeout=5`, 64 MiB socket buffers, `file-max=4194304`
-- **NIC optimization** — RPS/RFS across all cores, maximized ring buffers via ethtool, THP=always
-- **APT packages** — nikto, nmap, masscan, sqlmap, hydra, medusa, ncrack, tshark, hping3, tcpdump, netcat, ngrep, iperf3, mtr, sslscan, socat, dirb, whatweb, wrk, hey, vegeta, ethtool
-- **GitHub Releases** — nuclei, dalfox, ffuf, gobuster, feroxbuster, subfinder, httpx, amass
-- **Python packages** — mitmproxy, sslyze, dnsrecon, fierce, theHarvester, playwright, scapy, impacket, arjun
-- **Node.js 20.x** — Puppeteer with stealth plugin for bot simulation
-- **Browser automation** — Playwright Chromium for headless browser testing
-- **Git clones** — testssl.sh, recon-ng, spiderfoot, SecLists
-- **Suite deployment** — 17 traffic suites cloned from this repository to `/opt/traffic-generator/suites/`
-- **Config file** — `config.env` with `TARGET_FQDN`, `TARGET_ORIGIN_IP`, and `CRAPI_PORT`
+- **Kernel tuning** -- `somaxconn=131072`, `tcp_max_tw_buckets=4000000`, `tcp_fin_timeout=5`, 64 MiB socket buffers, `file-max=4194304`
+- **NIC optimization** -- RPS/RFS across all cores, maximized ring buffers via ethtool, THP=always
+- **APT packages** -- nikto, nmap, masscan, sqlmap, hydra, medusa, ncrack, tshark, hping3, tcpdump, netcat, ngrep, iperf3, mtr, sslscan, socat, dirb, whatweb, wrk, hey, vegeta, ethtool
+- **GitHub Releases** -- nuclei, dalfox, ffuf, gobuster, feroxbuster, subfinder, httpx, amass
+- **Python packages** -- mitmproxy, sslyze, dnsrecon, fierce, theHarvester, playwright, scapy, impacket, arjun
+- **Node.js 20.x** -- Puppeteer with stealth plugin for bot simulation
+- **Browser automation** -- Playwright Chromium for headless browser testing
+- **Git clones** -- testssl.sh, recon-ng, spiderfoot, SecLists
+- **Suite deployment** -- 17 traffic suites cloned from this repository to `/opt/traffic-generator/suites/`
+- **Config file** -- `config.env` with `TARGET_FQDN`, `TARGET_ORIGIN_IP`, and `CRAPI_PORT`
 
 The cloud-init uses Terraform template variables: `${target_fqdn}`, `${target_origin_ip}`, and `${tool_tier}`. Shell variables like `$NPROC` are escaped as `$$NPROC` in the Terraform templatefile.
 
@@ -64,7 +78,7 @@ The cloud-init uses Terraform template variables: `${target_fqdn}`, `${target_or
 
 ### Outputs
 
-`outputs.tf` exposes the public IP, SSH command, target FQDN, status check, and resource group:
+`outputs.tf` exposes 17 outputs including public/private IP, SSH command, resource identifiers, and component-specific values (target_fqdn, status_check):
 
 ```hcl file=./_data/outputs.tf
 ```
@@ -94,13 +108,13 @@ Terraform outputs the public IP, SSH command, and target FQDN after successful d
 
 The F-series compute-optimized VMs are recommended for this CPU-bound traffic generation workload. The cloud-init kernel tuning and tool concurrency scale automatically with vCPU count.
 
-| VM SKU | vCPU | RAM | Network | Use Case | Est. Monthly |
-|---|---|---|---|---|---|
-| Standard_F4s_v2 | 4 | 8 GiB | 10 Gbps | Light lab/demo | ~$97 |
-| Standard_F8s_v2 | 8 | 16 GiB | 12.5 Gbps | Standard demos | ~$194 |
-| Standard_F16s_v2 | 16 | 32 GiB | 12.5 Gbps | Load testing (default) | ~$389 |
-| Standard_F32s_v2 | 32 | 64 GiB | 16 Gbps | Heavy benchmarking | ~$778 |
-| Standard_D16s_v3 | 16 | 64 GiB | 12.5 Gbps | RAM-heavy workloads | ~$439 |
+| VM SKU | vCPU | RAM | Network | Use Case |
+|---|---|---|---|---|
+| Standard_F4s_v2 | 4 | 8 GiB | 10 Gbps | Light lab/demo |
+| Standard_F8s_v2 | 8 | 16 GiB | 12.5 Gbps | Standard demos |
+| Standard_F16s_v2 | 16 | 32 GiB | 12.5 Gbps | Load testing (default) |
+| Standard_F32s_v2 | 32 | 64 GiB | 16 Gbps | Heavy benchmarking |
+| Standard_D16s_v3 | 16 | 64 GiB | 12.5 Gbps | RAM-heavy workloads |
 
 :::tip
 F16s_v2 was validated as the optimal price-performance option by A/B/C/D benchmark testing against CDN F16s_v2 and F32s_v2 targets. See [benchmarks/](https://github.com/f5xc-salesdemos/traffic-generator/tree/main/benchmarks) for full results.
@@ -177,11 +191,23 @@ ls /opt/traffic-generator/suites/*/
 
 | Output | Description | Example |
 |---|---|---|
+| `deployer` | Resolved deployer identifier | `jsmith` |
 | `public_ip` | Public IP address of the traffic generator VM | `20.12.78.200` |
+| `private_ip` | Private IP address of the VM | `10.201.0.4` |
 | `ssh_command` | SSH command to connect to the VM | `ssh azureuser@20.12.78.200` |
+| `resource_group_name` | Resource group name | `rg-traffic-generator-dev-jsmith` |
+| `resource_group_id` | Resource group Azure resource ID | `/subscriptions/.../resourceGroups/rg-traffic-generator-dev-jsmith` |
+| `vm_name` | Virtual machine name | `vm-traffic-generator-dev-jsmith` |
+| `vm_id` | Virtual machine Azure resource ID | `/subscriptions/.../virtualMachines/vm-traffic-generator-dev-jsmith` |
+| `nsg_name` | Network security group name | `nsg-traffic-generator-dev-jsmith` |
+| `nsg_id` | Network security group Azure resource ID | `/subscriptions/.../networkSecurityGroups/nsg-traffic-generator-dev-jsmith` |
+| `vnet_name` | Virtual network name | `vnet-traffic-generator-dev-jsmith` |
+| `subnet_id` | Subnet Azure resource ID | `/subscriptions/.../subnets/snet-traffic-generator-dev-jsmith` |
+| `component` | Component identifier | `traffic-generator` |
+| `environment` | Deployment environment | `dev` |
+| `location` | Azure region | `eastus2` |
 | `target_fqdn` | Configured target FQDN for traffic suites | `demo.example.com` |
 | `status_check` | Command to check provisioning status | `ssh azureuser@20.12.78.200 cat /opt/traffic-generator/status.json` |
-| `resource_group` | Resource group containing all resources | `rg-traffic-generator` |
 
 Retrieve any output:
 

--- a/docs/04-tool-catalog.mdx
+++ b/docs/04-tool-catalog.mdx
@@ -103,7 +103,7 @@ SecLists provides wordlists used by multiple tools including ffuf, gobuster, fer
 
 ## Full Tier Only
 
-These tools are only installed when `install_tier = "full"`:
+These tools are only installed when `tool_tier = "full"`:
 
 | Tool | Install Method | Example Command | Used By Suite |
 |---|---|---|---|

--- a/docs/05-suites.mdx
+++ b/docs/05-suites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Traffic Suites
-description: "Detailed reference for all 7 traffic suites: web-app-attacks, api-attacks, bot-simulation, reconnaissance, ssl-scanning, javascript-exploits, and traffic-generation with scripts, tools, durations, and F5 XC feature mappings"
+description: "Detailed reference for all 17 traffic suites with scripts, tools, durations, and F5 XC feature mappings"
 sidebar:
   order: 5
 ---
@@ -9,50 +9,13 @@ import { Aside } from '@astrojs/starlight/components';
 
 Each traffic suite is a directory under `/opt/traffic-generator/suites/` containing numbered shell scripts executed in order by `runner.sh`. Every script accepts the target FQDN as its first argument and writes output to both stdout and the results directory.
 
-## web-app-attacks
-
-**Tests:** OWASP Top 10 web application vulnerabilities against Juice Shop and DVWA through F5 XC.
-
-**F5 XC Feature:** WAF (Web Application Firewall)
-
-**Estimated Duration:** 12-20 minutes
-
-| Order | Script | Tools | Description |
-|---|---|---|---|
-| 01 | `01-sqli.sh` | sqlmap, curl | SQL injection payloads against Juice Shop search API and DVWA SQLi endpoint. Runs sqlmap automated scans then sends 10 direct curl-based injection payloads. |
-| 02 | `02-xss.sh` | dalfox, curl | Cross-site scripting against Juice Shop and DVWA XSS reflected/stored endpoints. Runs dalfox automated scans then sends 12 direct XSS payloads including script tags, event handlers, and cookie exfiltration. |
-| 03 | `03-command-injection.sh` | curl | OS command injection payloads against DVWA exec endpoint. Sends 12 payloads including pipe chains, semicolons, URL-encoded newlines, and reverse shell patterns. |
-| 04 | `04-path-traversal.sh` | curl | Directory traversal against multiple application endpoints. Tests standard `../` traversals, URL-encoded variants, double-encoded variants, null-byte variants, and Unicode variants across 6 endpoint paths. |
-| 05 | `05-nikto-scan.sh` | nikto | Full web server vulnerability scan with 120-second time limit. Generates diverse HTTP requests that trigger WAF signature matching. |
-| 06 | `06-nuclei-scan.sh` | nuclei | Template-based vulnerability scanning at medium, high, and critical severity levels. Rate-limited to 50 requests/second. |
-
-**Expected F5 XC Behavior:** WAF should block or flag requests containing SQL injection, XSS, command injection, and path traversal payloads. The Security Events dashboard will show violation categories, signature IDs, and request details for each blocked request.
-
-**Example Output:**
-
-```
-=== 01-sqli.sh ===
-[*] SQL Injection suite against demo.example.com
-[+] Running sqlmap against Juice Shop search API...
-[+] Sending direct SQLi payloads via curl...
-  Payload: ' OR '1'='1
-    juice-shop/search -> HTTP 403
-    dvwa/sqli          -> HTTP 403
-[*] SQL Injection suite complete
-
-=== 02-xss.sh ===
-[*] XSS suite against demo.example.com
-[+] Running dalfox against Juice Shop search...
-...
-```
-
 ## api-attacks
 
-**Tests:** OWASP API Security Top 10 against VAmPI through F5 XC.
+**Scripts:** 4 | **Estimated Duration:** 10-17 minutes
+
+OWASP API Security Top 10 testing against VAmPI through F5 XC. Registers a test user, obtains an auth token, then tests BOLA, brute-force authentication, excessive data exposure, broken function-level authorization, SSRF patterns, SQL injection against REST API endpoints, hidden parameter discovery, and endpoint fuzzing. Targets the VAmPI application.
 
 **F5 XC Feature:** API Security / API Discovery
-
-**Estimated Duration:** 10-17 minutes
 
 | Order | Script | Tools | Description |
 |---|---|---|---|
@@ -63,29 +26,13 @@ Each traffic suite is a directory under `/opt/traffic-generator/suites/` contain
 
 **Expected F5 XC Behavior:** API Discovery should map the VAmPI API endpoints and identify unusual request patterns. API Security policies should flag unauthorized access attempts, injection payloads in JSON bodies, and enumeration patterns. The API Inventory in F5 XC will show discovered endpoints with request counts.
 
-**Example Output:**
-
-```
-=== 01-vampi-owasp-top10.sh ===
-[*] OWASP API Top 10 suite against VAmPI at demo.example.com
-[+] Registering test user...
-[+] Logging in as test user...
-    Token: eyJhbGciOiJIUzI1N...
-[+] API1: BOLA - Accessing other users' data...
-    GET /users/v1/admin  -> HTTP 403
-    GET /users/v1/user1  -> HTTP 403
-[+] API7: SSRF patterns...
-    SSRF http://169.254.169.254/latest/meta-data/ -> HTTP 403
-...
-```
-
 ## bot-simulation
 
-**Tests:** Automated browser activity and bot-like crawling patterns through F5 XC.
+**Scripts:** 4 | **Estimated Duration:** 5-10 minutes
+
+Automated browser activity and bot-like crawling patterns through F5 XC. Includes headless Chrome, Puppeteer with stealth plugin, rapid crawling, and automated form interaction. Targets all applications.
 
 **F5 XC Feature:** Bot Defense
-
-**Estimated Duration:** 5-10 minutes
 
 | Order | Script | Tools | Description |
 |---|---|---|---|
@@ -96,48 +43,53 @@ Each traffic suite is a directory under `/opt/traffic-generator/suites/` contain
 
 **Expected F5 XC Behavior:** Bot Defense should classify traffic as automated based on browser fingerprint analysis, request timing, and JavaScript challenge results. Headless Chrome without stealth should be detected immediately. Stealth Puppeteer tests whether advanced evasion techniques bypass detection. The Bot Defense dashboard will show bot classification categories and mitigation actions.
 
-## reconnaissance
+## cdn-load-testing
 
-**Tests:** Network scanning, service enumeration, and directory brute-forcing against the target infrastructure.
+**Scripts:** 18 | **Estimated Duration:** 20-30 minutes
 
-**F5 XC Feature:** WAF / Bot Defense
+CDN cache behavior and origin protection testing. Includes baseline throughput, query string isolation, accept-encoding variation, thundering herd simulation, POST/PUT bypass, cache key collision, conditional GET, range request, purge simulation, connection pool exhaustion, keepalive optimization, TLS handshake overhead, large object caching, multi-origin failover, rate limiting, gzip ratio testing, HTTP/2 multiplexing, and combined kraken benchmark. Targets the CDN Simulator application.
 
-**Estimated Duration:** 8-15 minutes
+**F5 XC Feature:** CDN Integration
 
-| Order | Script | Tools | Description |
-|---|---|---|---|
-| 01 | `01-nmap-scan.sh` | nmap | Service version detection and default script scan against the target's HTTP/HTTPS ports. |
-| 02 | `02-masscan-sweep.sh` | masscan | High-speed port scan of common web ports (80, 443, 8080, 8443) with rate limiting. |
-| 03 | `03-gobuster-dirs.sh` | gobuster | Directory brute-forcing using SecLists common wordlist against all application prefixes. |
-| 04 | `04-subfinder-enum.sh` | subfinder, httpx | Passive subdomain enumeration for the target domain, then HTTP probing of discovered hosts. |
-| 05 | `05-whatweb-fingerprint.sh` | whatweb | Web technology fingerprinting of the target and all application paths. |
-| 06 | `06-dns-recon.sh` | dnsrecon, fierce, dig | DNS record enumeration, zone transfer attempts, and reverse lookups for the target domain. |
+## crapi-exploits
 
-**Expected F5 XC Behavior:** WAF should detect and log scanning activity. Bot Defense may classify rapid sequential requests as automated. The Security Events dashboard will show reconnaissance signatures and scanning tool User-Agent strings.
+**Scripts:** 16 | **Estimated Duration:** 15-25 minutes
 
-## ssl-scanning
+OWASP crAPI (Completely Ridiculous API) challenge exploitation. Includes register/auth, BOLA vehicle location, BOLA mechanic reports, OTP bruteforce, data exposure mechanics, excessive data exposure, mass assignment orders, SSRF coupon validation, NoSQL injection, JWT manipulation, IDOR dashboard, 2FA bypass, internal API access, server-side parameter pollution, user deletion, and video upload IDOR. Targets the crAPI application.
 
-**Tests:** TLS/SSL configuration analysis of the F5 XC load balancer's HTTPS endpoint.
+**F5 XC Feature:** API Security
 
-**F5 XC Feature:** WAF (informational)
+## csd-demo-attacks
 
-**Estimated Duration:** 3-5 minutes
+**Scripts:** 5 (JavaScript) | **Estimated Duration:** 3-5 minutes
 
-| Order | Script | Tools | Description |
-|---|---|---|---|
-| 01 | `01-sslscan.sh` | sslscan | Enumerates supported cipher suites, protocol versions, and certificate details. |
-| 02 | `02-sslyze.sh` | sslyze | Comprehensive TLS analysis including certificate validation, cipher suite ordering, and vulnerability checks (Heartbleed, ROBOT, etc.). |
-| 03 | `03-testssl.sh` | testssl.sh | Full TLS assessment using the testssl.sh framework. Tests protocol support, cipher preferences, header analysis, and known vulnerabilities. |
+Client-side JavaScript injection attacks. Includes card skimmer injection, formjacker, keylogger, cryptominer, and DOM hijack scripts. Tests Magecart-style client-side supply chain attacks that F5 XC Client-Side Defense detects and blocks. Targets the CSD Demo application.
 
-**Expected F5 XC Behavior:** SSL scanning generates many TLS handshakes with unusual cipher suite proposals. While F5 XC does not typically block these, the traffic pattern is visible in access logs. The primary value is verifying that the F5 XC TLS configuration meets security best practices.
+**F5 XC Feature:** Client-Side Defense
+
+## dvga-exploits
+
+**Scripts:** 9 | **Estimated Duration:** 8-12 minutes
+
+GraphQL-specific vulnerability exploitation against the Damn Vulnerable GraphQL Application. Includes batch query DoS, deep recursion, field duplication, SQL injection via filter, XSS via createPaste, alias-based DoS, introspection abuse, authorization bypass, and information disclosure. Targets the DVGA application.
+
+**F5 XC Feature:** API Security (GraphQL)
+
+## dvwa-exploits
+
+**Scripts:** 14 | **Estimated Duration:** 15-25 minutes
+
+OWASP Top 10 testing against the Damn Vulnerable Web Application. Includes brute force, command injection, CSRF password change, file inclusion, file upload, SQL injection (blind), SQL injection (union), XSS (DOM), XSS (reflected), XSS (stored), CAPTCHA bypass, weak session IDs, insecure CORS, and open redirect. Targets the DVWA application.
+
+**F5 XC Feature:** WAF
 
 ## javascript-exploits
 
-**Tests:** Client-side script injection and DOM manipulation patterns that trigger Client-Side Defense detection.
+**Scripts:** 3 | **Estimated Duration:** 3-5 minutes
+
+Client-side script injection and DOM manipulation patterns that trigger Client-Side Defense detection. Includes inline script injection mimicking Magecart-style skimmers, DOM manipulation via headless Chromium, and third-party script simulation. Targets the CSD Demo application.
 
 **F5 XC Feature:** Client-Side Defense (CSD)
-
-**Estimated Duration:** 3-5 minutes
 
 | Order | Script | Tools | Description |
 |---|---|---|---|
@@ -151,13 +103,88 @@ Each traffic suite is a directory under `/opt/traffic-generator/suites/` contain
 The javascript-exploits suite is designed to work alongside the CSD demo application on the origin server. Ensure the origin server has the `/csd-demo/` path enabled before running this suite.
 </Aside>
 
+## juice-shop-exploits
+
+**Scripts:** 12 | **Estimated Duration:** 10-18 minutes
+
+OWASP Juice Shop challenge exploitation. Includes SQL injection login bypass, SQL injection search union, XSS DOM reflected, XSS stored API, IDOR basket access, admin section access, forged feedback, null byte file access, reflected XSS in search, HTTP header injection, repetitive registration, and login brute-force. Targets the Juice Shop application.
+
+**F5 XC Feature:** WAF, Bot Defense
+
+## mitre-attack
+
+**Scripts:** 8 | **Estimated Duration:** 10-15 minutes
+
+MITRE ATT&CK framework tactic simulation. Includes reconnaissance (external scanning), initial access (credential stuffing), execution (command injection), credential access (default passwords), discovery (directory enumeration), lateral movement simulation, collection (data scraping), and exfiltration simulation. Maps each script to a specific MITRE ATT&CK tactic for structured threat coverage reporting. Targets all applications.
+
+**F5 XC Feature:** WAF, Bot Defense, API Security
+
+## owasp-scanning
+
+**Scripts:** 10 | **Estimated Duration:** 20-35 minutes
+
+Comprehensive OWASP scanning suite using dedicated vulnerability scanners. Includes ZAP baseline scan, ZAP active scan, Nikto full scan, Nuclei full scan, Nmap vulnerability scan, SSL/TLS audit, directory fuzzing, subdomain enumeration, technology fingerprinting, and combined OWASP report generation. Targets all applications.
+
+**F5 XC Feature:** WAF, Web App Scanning
+
+## performance-testing
+
+**Scripts:** 12 | **Estimated Duration:** 15-30 minutes
+
+Performance characteristics testing under various load patterns. Includes concurrency ramp, per-app throughput, sustained load, connection churn, mixed attack+load, spike testing, endurance test, breakpoint discovery, response time percentiles, error rate under load, resource exhaustion, and latency distribution analysis. Targets all applications.
+
+**F5 XC Feature:** DDoS, Rate Limiting
+
+## reconnaissance
+
+**Scripts:** 6 | **Estimated Duration:** 8-15 minutes
+
+Network scanning, service enumeration, and directory brute-forcing against the target infrastructure. Includes nmap service detection, masscan port sweeps, directory brute-forcing, subdomain enumeration, web technology fingerprinting, and DNS reconnaissance. Targets all applications.
+
+**F5 XC Feature:** WAF / Bot Defense
+
+| Order | Script | Tools | Description |
+|---|---|---|---|
+| 01 | `01-nmap-scan.sh` | nmap | Service version detection and default script scan against the target's HTTP/HTTPS ports. |
+| 02 | `02-masscan-sweep.sh` | masscan | High-speed port scan of common web ports (80, 443, 8080, 8443) with rate limiting. |
+| 03 | `03-gobuster-dirs.sh` | gobuster | Directory brute-forcing using SecLists common wordlist against all application prefixes. |
+| 04 | `04-subfinder-enum.sh` | subfinder, httpx | Passive subdomain enumeration for the target domain, then HTTP probing of discovered hosts. |
+| 05 | `05-whatweb-fingerprint.sh` | whatweb | Web technology fingerprinting of the target and all application paths. |
+| 06 | `06-dns-recon.sh` | dnsrecon, fierce, dig | DNS record enumeration, zone transfer attempts, and reverse lookups for the target domain. |
+
+**Expected F5 XC Behavior:** WAF should detect and log scanning activity. Bot Defense may classify rapid sequential requests as automated. The Security Events dashboard will show reconnaissance signatures and scanning tool User-Agent strings.
+
+## restaurant-exploits
+
+**Scripts:** 11 | **Estimated Duration:** 10-18 minutes
+
+OWASP API Security Top 10 2023 testing against the Restaurant API application. Includes register/auth, BOLA profile, BOLA orders, BOPLA mass assignment, BFLA privilege escalation, rate limiting bypass, SQL injection menu, command injection disk stats, SSRF image URL, JWT weak secret, and sensitive data exposure. Targets the Restaurant API application.
+
+**F5 XC Feature:** API Security
+
+## ssl-scanning
+
+**Scripts:** 3 | **Estimated Duration:** 3-5 minutes
+
+TLS/SSL configuration analysis of the F5 XC load balancer's HTTPS endpoint. Enumerates cipher suites, protocol versions, certificate details, and checks for known TLS vulnerabilities. Targets the F5 XC load balancer endpoint.
+
+**F5 XC Feature:** WAF (informational)
+
+| Order | Script | Tools | Description |
+|---|---|---|---|
+| 01 | `01-sslscan.sh` | sslscan | Enumerates supported cipher suites, protocol versions, and certificate details. |
+| 02 | `02-sslyze.sh` | sslyze | Comprehensive TLS analysis including certificate validation, cipher suite ordering, and vulnerability checks (Heartbleed, ROBOT, etc.). |
+| 03 | `03-testssl.sh` | testssl.sh | Full TLS assessment using the testssl.sh framework. Tests protocol support, cipher preferences, header analysis, and known vulnerabilities. |
+
+**Expected F5 XC Behavior:** SSL scanning generates many TLS handshakes with unusual cipher suite proposals. While F5 XC does not typically block these, the traffic pattern is visible in access logs. The primary value is verifying that the F5 XC TLS configuration meets security best practices.
+
 ## traffic-generation
 
-**Tests:** High-volume legitimate HTTP traffic for baseline measurement and load testing.
+**Scripts:** 4 | **Estimated Duration:** 5-10 minutes (configurable)
+
+High-volume legitimate HTTP traffic for baseline measurement and load testing. Establishes normal traffic patterns in F5 XC analytics for comparison with attack suite traffic. Targets all applications.
 
 **F5 XC Feature:** All (baseline comparison)
-
-**Estimated Duration:** 5-10 minutes (configurable)
 
 | Order | Script | Tools | Description |
 |---|---|---|---|
@@ -167,3 +194,22 @@ The javascript-exploits suite is designed to work alongside the CSD demo applica
 | 04 | `04-user-journey.sh` | playwright | Simulates a realistic user journey: browsing pages, searching products, filling forms, and navigating between applications using Playwright with standard browser settings. |
 
 **Expected F5 XC Behavior:** All requests in this suite should pass through without WAF or Bot Defense intervention. Use this suite to generate "clean" traffic in the analytics dashboard, then compare with attack suite traffic to demonstrate the difference between legitimate and malicious request patterns.
+
+## web-app-attacks
+
+**Scripts:** 6 | **Estimated Duration:** 12-20 minutes
+
+OWASP Top 10 web application vulnerability testing against Juice Shop and DVWA through F5 XC. Includes SQL injection, XSS, command injection, path traversal, Nikto scanning, and Nuclei template-based scanning. Targets the Juice Shop and DVWA applications.
+
+**F5 XC Feature:** WAF (Web Application Firewall)
+
+| Order | Script | Tools | Description |
+|---|---|---|---|
+| 01 | `01-sqli.sh` | sqlmap, curl | SQL injection payloads against Juice Shop search API and DVWA SQLi endpoint. Runs sqlmap automated scans then sends 10 direct curl-based injection payloads. |
+| 02 | `02-xss.sh` | dalfox, curl | Cross-site scripting against Juice Shop and DVWA XSS reflected/stored endpoints. Runs dalfox automated scans then sends 12 direct XSS payloads including script tags, event handlers, and cookie exfiltration. |
+| 03 | `03-command-injection.sh` | curl | OS command injection payloads against DVWA exec endpoint. Sends 12 payloads including pipe chains, semicolons, URL-encoded newlines, and reverse shell patterns. |
+| 04 | `04-path-traversal.sh` | curl | Directory traversal against multiple application endpoints. Tests standard `../` traversals, URL-encoded variants, double-encoded variants, null-byte variants, and Unicode variants across 6 endpoint paths. |
+| 05 | `05-nikto-scan.sh` | nikto | Full web server vulnerability scan with 120-second time limit. Generates diverse HTTP requests that trigger WAF signature matching. |
+| 06 | `06-nuclei-scan.sh` | nuclei | Template-based vulnerability scanning at medium, high, and critical severity levels. Rate-limited to 50 requests/second. |
+
+**Expected F5 XC Behavior:** WAF should block or flag requests containing SQL injection, XSS, command injection, and path traversal payloads. The Security Events dashboard will show violation categories, signature IDs, and request details for each blocked request.

--- a/docs/07-integrate.mdx
+++ b/docs/07-integrate.mdx
@@ -31,13 +31,23 @@ The [origin server](https://f5xc-salesdemos.github.io/origin-server/) provides t
 
 | Traffic Suite | Origin Application | Path |
 |---|---|---|
-| web-app-attacks | Juice Shop, DVWA | `/juice-shop/`, `/dvwa/` |
 | api-attacks | VAmPI | `/vampi/` |
 | bot-simulation | All applications | All paths |
-| reconnaissance | All applications | All paths |
-| ssl-scanning | F5 XC LB (not origin directly) | N/A |
+| cdn-load-testing | CDN Simulator | CDN endpoint |
+| crapi-exploits | crAPI | `/crapi/` |
+| csd-demo-attacks | CSD Demo | `/csd-demo/` |
+| dvga-exploits | DVGA | `/dvga/` |
+| dvwa-exploits | DVWA | `/dvwa/` |
 | javascript-exploits | CSD Demo | `/csd-demo/` |
+| juice-shop-exploits | Juice Shop | `/juice-shop/` |
+| mitre-attack | All applications | All paths |
+| owasp-scanning | All applications | All paths |
+| performance-testing | All applications | All paths |
+| reconnaissance | All applications | All paths |
+| restaurant-exploits | Restaurant API | `/restaurant/` |
+| ssl-scanning | F5 XC LB (not origin directly) | N/A |
 | traffic-generation | All applications | All paths |
+| web-app-attacks | Juice Shop, DVWA | `/juice-shop/`, `/dvwa/` |
 
 ### Deployment Order
 

--- a/docs/08-teardown.mdx
+++ b/docs/08-teardown.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teardown
-description: "terraform destroy to remove all Azure resources (rg-traffic-generator), verify resource group deletion with az CLI, clean local state files, and stop ongoing billing at approximately $389 USD/month"
+description: "terraform destroy to remove all Azure resources, verify resource group deletion with az CLI, and clean local state files"
 sidebar:
   order: 8
 ---
@@ -26,11 +26,13 @@ Terraform will prompt for confirmation. Type `yes` to proceed.
 Confirm all resources have been removed:
 
 ```bash
-az group show --name rg-traffic-generator 2>&1 | grep -q "ResourceGroupNotFound" \
+RG_NAME=$(terraform output -raw resource_group_name)
+
+az group show --name "${RG_NAME}" 2>&1 | grep -q "ResourceGroupNotFound" \
   && echo "Resource group deleted" \
   || echo "Resource group still exists"
 
-az resource list --resource-group rg-traffic-generator -o table 2>/dev/null
+az resource list --resource-group "${RG_NAME}" -o table 2>/dev/null
 ```
 
 ## Clean Up Local State
@@ -65,10 +67,6 @@ If you also want to remove the F5 XC configuration that the traffic generator wa
 3. Delete any WAF policies, Bot Defense configurations, API Security policies, or CSD configurations created for testing
 
 These F5 XC resources do not incur Azure costs but should be cleaned up when the demo environment is no longer needed.
-
-## Cost Reference
-
-While running, the traffic generator costs approximately **$389 USD/month** (Standard_F16s_v2 VM + Public IP + Premium SSD). After `terraform destroy`, all charges stop. There are no residual costs from deleted resources.
 
 :::tip
 For recurring demo use, consider scripting the full lifecycle: `cd terraform && terraform apply` before a demo, run suites, then `terraform destroy` afterward. The standard tier provisions in 15-20 minutes, making same-day setup and teardown practical.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -28,13 +28,23 @@ All tools are pre-installed via cloud-init during Terraform provisioning. Traffi
 
 | Suite | Description | F5 XC Feature Validated |
 |---|---|---|
-| [web-app-attacks](/traffic-generator/05-suites/#web-app-attacks) | SQL injection, XSS, command injection, path traversal, Nikto, Nuclei | WAF |
 | [api-attacks](/traffic-generator/05-suites/#api-attacks) | OWASP API Top 10, SQLMap API mode, parameter discovery, endpoint fuzzing | API Security |
 | [bot-simulation](/traffic-generator/05-suites/#bot-simulation) | Headless Chrome, Puppeteer stealth, Playwright automation, rapid crawling | Bot Defense |
-| [reconnaissance](/traffic-generator/05-suites/#reconnaissance) | Nmap, Masscan, Gobuster, Subfinder, directory brute-forcing | WAF / Bot Defense |
-| [ssl-scanning](/traffic-generator/05-suites/#ssl-scanning) | SSLScan, sslyze, testssl.sh TLS configuration analysis | WAF |
+| [cdn-load-testing](/traffic-generator/05-suites/#cdn-load-testing) | Cache behavior, thundering herd, connection pool, HTTP/2 multiplexing | CDN Integration |
+| [crapi-exploits](/traffic-generator/05-suites/#crapi-exploits) | BOLA, OTP bruteforce, JWT manipulation, SSRF, NoSQL injection, IDOR | API Security |
+| [csd-demo-attacks](/traffic-generator/05-suites/#csd-demo-attacks) | Card skimmer, formjacker, keylogger, cryptominer, DOM hijack | Client-Side Defense |
+| [dvga-exploits](/traffic-generator/05-suites/#dvga-exploits) | Batch query DoS, deep recursion, SQL injection, introspection abuse | API Security (GraphQL) |
+| [dvwa-exploits](/traffic-generator/05-suites/#dvwa-exploits) | Brute force, command injection, CSRF, file inclusion, SQLi, XSS | WAF |
 | [javascript-exploits](/traffic-generator/05-suites/#javascript-exploits) | DOM manipulation, inline script injection, Magecart-style skimming payloads | Client-Side Defense |
+| [juice-shop-exploits](/traffic-generator/05-suites/#juice-shop-exploits) | SQLi login bypass, XSS, IDOR, admin access, null byte file access | WAF, Bot Defense |
+| [mitre-attack](/traffic-generator/05-suites/#mitre-attack) | ATT&CK tactics: recon, initial access, credential access, exfiltration | WAF, Bot Defense, API Security |
+| [owasp-scanning](/traffic-generator/05-suites/#owasp-scanning) | ZAP, Nikto, Nuclei, Nmap vulnerability scanning, combined OWASP report | WAF, Web App Scanning |
+| [performance-testing](/traffic-generator/05-suites/#performance-testing) | Concurrency ramp, sustained load, spike testing, breakpoint discovery | DDoS, Rate Limiting |
+| [reconnaissance](/traffic-generator/05-suites/#reconnaissance) | Nmap, Masscan, Gobuster, Subfinder, directory brute-forcing | WAF / Bot Defense |
+| [restaurant-exploits](/traffic-generator/05-suites/#restaurant-exploits) | BOLA, BOPLA, BFLA, rate limiting bypass, JWT weak secret | API Security |
+| [ssl-scanning](/traffic-generator/05-suites/#ssl-scanning) | SSLScan, sslyze, testssl.sh TLS configuration analysis | WAF |
 | [traffic-generation](/traffic-generator/05-suites/#traffic-generation) | High-volume legitimate HTTP traffic for baseline and load testing | All |
+| [web-app-attacks](/traffic-generator/05-suites/#web-app-attacks) | SQL injection, XSS, command injection, path traversal, Nikto, Nuclei | WAF |
 
 <CardGrid>
   <LinkCard


### PR DESCRIPTION
## Summary

Major documentation rewrite to match current code state after terraform standardization and cloud-init hardening.

**Suite documentation (10 new suites):**
- Documented all 17 traffic suites (was only 7): cdn-load-testing, crapi-exploits, csd-demo-attacks, dvga-exploits, dvwa-exploits, juice-shop-exploits, mitre-attack, owasp-scanning, performance-testing, restaurant-exploits
- Updated index, architecture, suites, and integrate pages with complete suite inventory

**Terraform standardization:**
- 9-file terraform structure documented (versions.tf, providers.tf, data.tf, locals.tf, main.tf, network.tf, vm.tf, outputs.tf)
- Deployer auto-resolution from Azure AD documented
- 17 outputs documented (15 standard + 2 component-specific)
- Cloud-init helper library and progress logging documented

**Pricing removal:**
- Removed all cost tables from 01-architecture, 02-prerequisites, 03-deploy, 08-teardown
- Azure pricing calculator is the source of truth

**Bug fixes:**
- `install_tier` → `tool_tier` in architecture and tool-catalog pages
- Hardcoded `rg-traffic-generator` → `$(terraform output -raw resource_group_name)`

Closes #51

## Test plan
- [x] All pricing references removed
- [x] All 17 suites documented with script counts and F5 XC feature mappings
- [x] install_tier → tool_tier corrected
- [x] Hardcoded resource names replaced with terraform output