### PR TITLE
docs: add component name and dependency context to deployment custom set description

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -2,7 +2,7 @@
   "customSets": [
     {
       "label": "Deployment",
-      "description": "Terraform IaC deployment with prerequisites and teardown",
+      "description": "Traffic Generator Terraform deployment — requires subscription_id and target_fqdn of the F5 XC load balancer",
       "paths": ["02-prerequisites*", "03-deploy*", "08-teardown*"]
     },
     {


### PR DESCRIPTION
## Summary

- Updated the Deployment customSet description in `docs/llms-config.json` from a generic label to one that identifies the component and its required inputs
- The starlight-llms-txt plugin uses this description as the SYSTEM tag header in `deployment.txt`, so specificity helps AI assistants distinguish between different components' deployment guides

Closes #57

## Test plan

- [ ] CI checks pass
- [ ] Verify `docs/llms-config.json` parses as valid JSON
- [ ] Confirm the new description appears in the generated `deployment.txt` SYSTEM tag after site rebuild