### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
-ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine
+skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored,*.generated.ts
+ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine,dentify,opps,pecified,atmost,atleast

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -30,6 +30,9 @@ jobs:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
+      ORG_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      ORG_RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      ORG_REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,20 @@ docs/api-reference/
 .etag
 .github_release
 
+# Autoresearch session artifacts
+autoresearch.sh
+autoresearch.md
+autoresearch.program.md
+autoresearch.checks.sh
+autoresearch-loop.sh
+autoresearch.ideas.md
+autoresearch-queries.txt
+autoresearch.jsonl
+.autoresearch/
+
+# Session-resume files
+handoff.md
+
 # Union from xcsh fork (promoted 2026-04-19)
 .npm/
 packages/*/dist/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Repository Settings](https://github.com/f5xc-salesdemos/traffic-generator/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/traffic-generator/actions/workflows/enforce-repo-settings.yml)
 [![License](https://img.shields.io/github/license/f5xc-salesdemos/traffic-generator)](LICENSE)
 
-Azure traffic generator with 160+ security testing scripts across 19 suites for F5 XC demo environments
+Azure traffic generator with 150+ security testing scripts across 17 suites for F5 XC demo environments
 
 ## Documentation
 


### PR DESCRIPTION
Closes #129

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/workflows/enforce-repo-settings.yml
- .gitignore
- .codespellrc
- README.md